### PR TITLE
[WIP] Queuing - this time for real

### DIFF
--- a/lib/frontend/app.js
+++ b/lib/frontend/app.js
@@ -80,7 +80,7 @@ module.exports = (appTokenGenerator) => {
 
   app.get('/jira/configuration', verifyJiraMiddleware, getJiraConfiguration)
   app.delete('/jira/configuration', verifyJiraMiddleware, deleteJiraConfiguration)
-  app.get('/jira/sync', retrySync)
+  app.get('/jira/sync/:owner/:repo', retrySync)
 
   app.get('/', async (req, res, next) => {
     const { data: info } = (await res.locals.client.apps.get({}))

--- a/lib/frontend/retry-sync.js
+++ b/lib/frontend/retry-sync.js
@@ -6,8 +6,9 @@ module.exports = async (req, res, next) => {
   }
 
   const subscription = await Subscription.getSingleInstallation(req.query.host, req.query.installationId)
+  const { owner, repo } = req.params
 
-  await Subscription.findOrStartSync(subscription)
+  await Subscription.syncRepository(subscription, { owner, repo })
 
   return res.sendStatus(202)
 }

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -47,8 +47,6 @@ module.exports = class Subscription extends Sequelize.Model {
       }
     })
 
-    Subscription.findOrStartSync(subscription)
-
     return subscription
   }
 
@@ -61,9 +59,22 @@ module.exports = class Subscription extends Sequelize.Model {
     })
   }
 
-  static async findOrStartSync (subscription) {
+  static async syncRepository (subscription, { owner, repo }) {
     const { gitHubInstallationId: installationId, jiraHost } = subscription
     const { queues } = require('../worker')
+    const app = require('../worker/app')
+    const github = await app.auth(installationId)
+    const { data } = await github.repos.get({ owner, repo })
+
+    // Making the repository object smaller since it gets passed around
+    // to all the jobs in memory
+    const repository = {
+      id: data.id,
+      full_name: data.full_name,
+      html_url: data.html_url,
+      name: data.name,
+      owner: data.owner
+    }
 
     await subscription.update({
       syncStatus: 'PENDING',
@@ -74,9 +85,7 @@ module.exports = class Subscription extends Sequelize.Model {
       }
     })
 
-    console.log('Starting Jira sync')
-
-    queues.discovery.add({ installationId, jiraHost })
+    queues.master.add({ installationId, jiraHost, repository })
   }
 
   async uninstall () {

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -3,77 +3,78 @@ const Queue = require('bull')
 const { processPullRequests } = require('../sync/pull-request')
 const { processCommits } = require('../sync/commits.js')
 const { processBranches } = require('../sync/branches.js')
-const { discovery } = require('../sync/discovery')
-const limterPerInstallation = require('./limiter')
 
 const app = require('./app')
-const getJiraClient = require('../jira/client')
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
-const { CONCURRENT_WORKERS = 1 } = process.env
-
-// Setup queues
-const queues = {
-  discovery: new Queue('Content discovery', REDIS_URL),
-  pullRequests: new Queue('Pull Requests transformation', REDIS_URL),
-  commits: new Queue('Commit transformation', REDIS_URL),
-  branches: new Queue('Branch transformation', REDIS_URL)
-}
-
-// Setup error handling for queues
-Object.keys(queues).forEach(name => {
-  const queue = queues[name]
-
-  queue.on('error', (err) => {
-    app.log.error({err, queue: name})
-  })
-
-  queue.on('failed', (job, err) => {
-    app.log.error({job, err, queue: name})
-  })
-})
-
-queues.commits.on('completed', async (job, result) => {
-  app.log('commits queue completed for job:', job.id)
-  const jiraClient = await getJiraClient(job.id, job.data.installationId, job.data.jiraHost)
-  try {
-    await jiraClient.devinfo.migration.complete()
-  } catch (err) {
-    app.log.error(err)
-  }
-})
 
 module.exports = {
-  queues,
+  queues: {
+    // Master queue used for passing data between web and workers
+    master: new Queue('master', REDIS_URL),
+
+    getForInstallation: (installationId) => {
+      const name = `installation-${installationId}`
+      if (this[name]) return this[name]
+
+      const queue = new Queue(name, REDIS_URL, {
+        // Run 1 job at a time every 5 seconds
+        limiter: { max: 1, duration: 5000 }
+      })
+
+      queue.on('error', (err) => {
+        app.log.error({err, queue: name})
+      })
+
+      queue.on('failed', (job, err) => {
+        app.log.error({job, err, queue: name})
+      })
+
+      queue.on('global:completed', async () => {
+        // This event is called when any job is completed
+        // so check and see how many jobs are left
+        // before closing the queue
+        const count = await queue.count()
+        if (count === 0) {
+          queue.close().then(() => {
+            app.log.info(`Queue for Installation-${installationId} closed`)
+            delete this[name]
+          })
+        }
+      })
+
+      return queue
+    }
+  },
 
   start () {
-    queues.pullRequests.process(Number(CONCURRENT_WORKERS), limterPerInstallation(processPullRequests(app)))
-    queues.commits.process(Number(CONCURRENT_WORKERS), limterPerInstallation(processCommits(app)))
-    queues.branches.process(Number(CONCURRENT_WORKERS), limterPerInstallation(processBranches(app)))
-    queues.discovery.process(5, limterPerInstallation(discovery(app, queues)))
+    app.log('Worker process started')
+    this.queues.master.process(job => {
+      // Get a queue for this installation
+      const queue = this.queues.getForInstallation(job.data.installationId)
 
-    app.log(`Worker process started with ${CONCURRENT_WORKERS} CONCURRENT WORKERS`)
+      app.log(`Processing ${job.data.installationId} on ${queue.name}`)
+
+      // Add commits branches and PR jobs to the queue
+      queue.add('commits', job.data)
+      queue.add('branches', job.data)
+      queue.add('pull requests', job.data)
+      // Named processors for each job type
+      queue.process('commits', processCommits(app))
+      queue.process('branches', processBranches(app))
+      queue.process('pull requests', processPullRequests(app))
+    })
   },
 
   async clean () {
     return Promise.all([
-      queues.discovery.clean(10000, 'completed'),
-      queues.discovery.clean(10000, 'failed'),
-      queues.pullRequests.clean(10000, 'completed'),
-      queues.pullRequests.clean(10000, 'failed'),
-      queues.commits.clean(10000, 'completed'),
-      queues.commits.clean(10000, 'failed'),
-      queues.branches.clean(10000, 'completed'),
-      queues.branches.clean(10000, 'failed')
+      this.queues.master.clean()
     ])
   },
 
   async stop () {
     return Promise.all([
-      queues.pullRequests.close(),
-      queues.commits.close(),
-      queues.branches.close(),
-      queues.discovery.close()
+      this.queues.master.close()
     ])
   }
 }

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -50,7 +50,8 @@ $('.sync-connection-link').click(function (event) {
 
   $.ajax({
     type: 'GET',
-    url: `/jira/sync`,
+    // TODO: make this work for real
+    url: `/jira/sync/tcbyrd/testrepo`,
     data: {
       installationId: $(event.target).data('installation-id'),
       host: $(event.target).data('jira-host')


### PR DESCRIPTION
After some discussion with @bkeepers and @gimenete we decided to go the route of dynamically creating queues for each installation ID. To accomplish this, @gimenete gave me a quick idea for this `getForInstallation` method:

```js
getForInstallation(installationId) {
  const name = `installation-${installationId}`
  if (queues[name]) return queues[name]
  const queue = new Queue(name, redisConnection)
  queue.on('complete', () => {
    queue.close()
    delete queues[name]
  })
  queues[name] = queue
  return queue
}
```
I ran with that idea and modified the `worker.start()` method to spin up a small message bus that receives the job from `Subscription.syncRepository` and creates the queue from there.  A huge benefit here is we can actually use Bull's rate limiting features to guarantee each installation is only processing one job at a time on an interval we specify (currently set to 5000ms, but we can probably reuse the `LIMITER_PER_INSTALLATION` variable we setup before)

TODOs:
- [ ] Setup a properly authenticated route from the web page to initiate the sync job
- [ ] Update the UI to allow for syncing a specific repository (see [current DVCS UI](https://marketplace-cdn.atlassian.com/files/images/com.atlassian.jira.plugins.jira-bitbucket-connector-plugin/89b25236-c47e-4006-89c2-2800e5fab4d5.png) for inspiration)
- [ ] Figure out how to handle the existing queues (maybe a separate worker script that processes what's left?)
- [ ] Reimplement #112 to use these dynamic queues
- [ ] Write tests
- [ ] Anything else?
