### PR TITLE
Open public url from within iframe

### DIFF
--- a/lib/frontend/get-jira-configuration.js
+++ b/lib/frontend/get-jira-configuration.js
@@ -32,6 +32,7 @@ module.exports = async (req, res) => {
     host: req.query.xdm_e,
     connections,
     failedConnections,
-    hasConnections: connections.length > 0 || failedConnections.length > 0
+    hasConnections: connections.length > 0 || failedConnections.length > 0,
+    APP_URL: process.env.APP_URL
   })
 }

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -3,8 +3,9 @@ const params = new URLSearchParams(window.location.search.substring(1))
 
 $('.add-organization-link').click(function (event) {
   event.preventDefault()
+  const appUrl = document.querySelector('meta[name=public-url]').getAttribute('content')
 
-  const child = window.open(`https://jira.tcbyrd.app/github/redirect?jwt=${encodeURIComponent(params.get('jwt'))}&xdm_e=${encodeURIComponent(params.get('xdm_e'))}`)
+  const child = window.open(`${appUrl}/github/redirect?jwt=${encodeURIComponent(params.get('jwt'))}&xdm_e=${encodeURIComponent(params.get('xdm_e'))}`)
 
   const interval = setInterval(function () {
     if (child.closed) {

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -4,7 +4,7 @@ const params = new URLSearchParams(window.location.search.substring(1))
 $('.add-organization-link').click(function (event) {
   event.preventDefault()
 
-  const child = window.open(`/github/redirect?jwt=${encodeURIComponent(params.get('jwt'))}&xdm_e=${encodeURIComponent(params.get('xdm_e'))}`)
+  const child = window.open(`https://jira.tcbyrd.app/github/redirect?jwt=${encodeURIComponent(params.get('jwt'))}&xdm_e=${encodeURIComponent(params.get('xdm_e'))}`)
 
   const interval = setInterval(function () {
     if (child.closed) {

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="ap-local-base-url" content="{{localBaseUrl}}">
+    <meta name="public-url" content="{{APP_URL}}">
     <title>{{title}}</title>
     <link rel="stylesheet" href="/public/css-reset/bundle.css" media="all" />
     <link rel="stylesheet" href="/public/atlassian-ui-kit/bundle.css" media="all" />


### PR DESCRIPTION
This allows the iframe to remain a heroku URL while ensuring that when we send users to a GitHub specific page, it will show the official GitHub URL.