### PR TITLE
Pin bottleneck to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1153,9 +1153,9 @@
       }
     },
     "bottleneck": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.10.0.tgz",
-      "integrity": "sha512-9bZR9Ard7oLKa4vPwQ1tMRkRGl3jRghqqilK4NFBKSYyaRZl4nYe8Yzrtzq/BXMRMOPSD3lnHcRRhWQ0WtCL6w=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.9.0.tgz",
+      "integrity": "sha512-XXCbAhE5KtVBJD5KW1tqgaA+dopWWwSir+2168fjfmhCPlRKfGuh+yQnNpps1LVr1ow7K1gD2qOeOjHfTNsTQw=="
     },
     "boxen": {
       "version": "1.3.0",
@@ -6065,7 +6065,7 @@
     },
     "lru-cache": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
       "integrity": "sha1-tcvwFVbBaWb+vlTO7A+03JDfbCg=",
       "requires": {
         "pseudomap": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "atlassian-jwt": "^0.1.5",
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",
-    "bottleneck": "^2.9.0",
+    "bottleneck": "2.9.0",
     "bull": "^3.4.7",
     "cookie-session": "^2.0.0-beta.3",
     "csurf": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "atlassian-jwt": "^0.1.5",
     "axios": "^0.18.0",
     "body-parser": "^1.18.3",
+    "bottleneck": "^2.9.0",
     "bull": "^3.4.7",
     "cookie-session": "^2.0.0-beta.3",
     "csurf": "^1.9.0",


### PR DESCRIPTION
This is a temporary fix to avoid the memory leak issues we're seeing with 2.10.0. See https://github.com/SGrondin/bottleneck/issues/95#issuecomment-442488867 for more details