### PR TITLE
Update the SUPPORT file with troubleshooting steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Existing users of Jira's built-in DVCS connector that meet the [requirements](#r
 3. Follow the prompt to upgrade your GitHub connection
 
 ## Questions? Need help?
-Please fill out GitHub's [Support form](https://github.com/contact?form%5Bsubject%5D=Re:+GitHub%2BJira+Integration) and your request will be routed to the right team at GitHub.
+Take a look through the [troubleshooting steps in our support guide](SUPPORT.md).
 
 ## Contributing
 Want to help improve the integration between GitHub and Jira? Check out the [contributing docs](CONTRIBUTING.md) to get involved.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,2 +1,55 @@
-# Questions? Need help?
+# Questions? Need help? You've come to the right place
+
+This file will help you troubleshoot the common issues that can occur with the  GitHub.com + Jira Software integration. 
+
+## Table of Contents
+
+- [App is not responding](#app-is-not-responding)
+- [Sync status not reaching complete](#sync-status-not-reaching-complete)
+- [Nothing showing up in Jira](#nothing-showing-up-in-jira)
+- [Getting additional help](#getting-additional-help)
+
+## App is not responding
+
+After installing the integration, clicking "Getting started" in Jira can lead to a page that shows a GitHub error page with the message `App is not responding. Wait or cancel.`
+
+Uninstalling and reinstalling the integration is the most common fix for this.
+
+1. Click **Uninstall** from the Manage Apps page of your Jira settings.
+2. Reinstall the [integration using this link](https://marketplace-cdn.atlassian.com/files/1.1.0-AC/artifact/descriptor/345df622-da2f-4b1f-a5a3-068806c57031/atlassian-connect.json).
+
+Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
+
+## Sync status not reaching complete
+
+After installing the integration, your sync status should move from `PENDING` to `ACTIVE` to `COMPLETE`. 
+
+The sync should take a maximum of ~5 hours. If your sync status is still `ACTIVE` after 5 hours:
+
+1. Open the integration settings: **Jira Settings** -> **Add-ons** -> **Manage Add-ons** -> **GitHub** -> **Get started**
+2. Click the **Retry** button
+
+If after another 5 hours your status is still not `COMPLETE`, try selecting just the repositories that Jira needs access to:
+
+1. Open the GitHub Apps settings in GitHub.
+2. Click **Configure** on Jira.
+3. In Repository access, select only the repositories that Jira needs access to
+4. Click **Save**
+
+This will automatically start a new sync.
+
+Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
+
+## Nothing showing up in Jira
+
+Check that you're adding your Jira issue keys in your commits, branches, or pull request titles. These are the only places on GitHub where you can put your Jira issue keys that will cause updates to be sent to the Jira issue.
+
+For more information, check out [Using the integration](https://github.com/integrations/jira#using-the-integration).
+
+Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
+
+## Getting additional help
+
 Please fill out GitHub's [Support form](https://github.com/contact?form%5Bsubject%5D=Re:+GitHub%2BJira+Integration) and your request will be routed to the right team at GitHub.
+
+Be sure to include the details of any troubleshooting steps you've tried so far.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -16,7 +16,8 @@ After installing the integration, clicking "Getting started" in Jira can lead to
 Uninstalling and reinstalling the integration is the most common fix for this.
 
 1. Click **Uninstall** from the Manage Apps page of your Jira settings.
-2. Reinstall the [integration using this link](https://marketplace-cdn.atlassian.com/files/1.1.0-AC/artifact/descriptor/345df622-da2f-4b1f-a5a3-068806c57031/atlassian-connect.json).
+2. Click **Settings** and enable **Developer Mode**.
+3. Click **Upload App** and [paste this URL to reinstall the integration](https://marketplace-cdn.atlassian.com/files/1.1.0-AC/artifact/descriptor/345df622-da2f-4b1f-a5a3-068806c57031/atlassian-connect.json).
 
 Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -24,6 +24,10 @@ Still having trouble? [Contact GitHub Support for additional help](#getting-addi
 
 After installing the integration, your sync status should move from `PENDING` to `ACTIVE` to `COMPLETE`. 
 
+You can check your sync status in the integration settings:
+
+**Jira Settings** -> **Add-ons** -> **Manage Add-ons** -> **GitHub** -> **Get started**
+
 ### Sync status definitions
 
 | Status   | Definition                 |
@@ -50,7 +54,9 @@ Still having trouble? [Contact GitHub Support for additional help](#getting-addi
 
 ## Nothing showing up in Jira
 
-Check that you're adding your Jira issue keys in your commits, branches, or pull request titles. These are the only places on GitHub where you can put your Jira issue keys that will cause updates to be sent to the Jira issue.
+First [check that your sync status has reached `COMPLETE`](#sync-status-not-reaching-complete). No information will be displayed in Jira until the status is `COMPLETE`.
+
+Next check that you're adding your Jira issue keys in your commits, branches, or pull request titles. These are the only places on GitHub where you can put your Jira issue keys that will cause updates to be sent to the Jira issue.
 
 For more information, check out [Using the integration](https://github.com/integrations/jira#using-the-integration).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,6 +7,7 @@ This file will help you troubleshoot the common issues that can occur with the  
 - [App is not responding](#app-is-not-responding)
 - [Sync status not reaching complete](#sync-status-not-reaching-complete)
 - [Nothing showing up in Jira](#nothing-showing-up-in-jira)
+- [Workflow transitions are not running](#workflow-transitions-are-not-running)
 - [Getting additional help](#getting-additional-help)
 
 ## App is not responding
@@ -59,6 +60,18 @@ First [check that your sync status has reached `COMPLETE`](#sync-status-not-reac
 Next check that you're adding your Jira issue keys in your commits, branches, or pull request titles. These are the only places on GitHub where you can put your Jira issue keys that will cause updates to be sent to the Jira issue.
 
 For more information, check out [Using the integration](https://github.com/integrations/jira#using-the-integration).
+
+Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
+
+## Workflow transitions are not running
+
+In order for transitions to run from your smart commit syntax, a permissions requirement must be met.
+
+The email address used for the commit in GitHub that has the transition in the commit message must match an email address that has permission to run the transition in your Jira instance.
+
+You can check the email address on GitHub by adding `.patch` to the end of a commit URL. For example:
+
+`https://github.com/atom/atom/commit/834f8f3d73d84e98a423fe0720abd833d5ca7a87.patch`
 
 Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -24,6 +24,14 @@ Still having trouble? [Contact GitHub Support for additional help](#getting-addi
 
 After installing the integration, your sync status should move from `PENDING` to `ACTIVE` to `COMPLETE`. 
 
+### Sync status definitions
+
+| Status   | Definition                 |
+|----------|----------------------------|
+| PENDING  | The sync has not started.  |
+| ACTIVE   | The sync has started and is still in progress. No information will be displayed in Jira. |
+| COMPLETE | The sync has finished. Information will be displayed in Jira. |
+
 The sync should take a maximum of ~5 hours. If your sync status is still `ACTIVE` after 5 hours:
 
 1. Open the integration settings: **Jira Settings** -> **Add-ons** -> **Manage Add-ons** -> **GitHub** -> **Get started**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -16,8 +16,7 @@ After installing the integration, clicking "Getting started" in Jira can lead to
 Uninstalling and reinstalling the integration is the most common fix for this.
 
 1. Click **Uninstall** from the Manage Apps page of your Jira settings.
-2. Click **Settings** and enable **Developer Mode**.
-3. Click **Upload App** and [paste this URL to reinstall the integration](https://marketplace-cdn.atlassian.com/files/1.1.0-AC/artifact/descriptor/345df622-da2f-4b1f-a5a3-068806c57031/atlassian-connect.json).
+2. Visit the Atlassian Marketplace and install the [GitHub for Jira app](https://marketplace.atlassian.com/apps/1219592/github-for-jira?hosting=cloud&tab=overview).
 
 Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
 


### PR DESCRIPTION
This pull request updates the `SUPPORT.md` file with troubleshooting steps for the most commonly seen problems so far.

This change should help in a few ways:
1. Quick self-service for people to help themselves
2. Documentation that the support team at GitHub can reference

The `README.md` file has been updated to link people to the `SUPPORT.md` file instead of linking directly to the GitHub Support contact form.