### PR TITLE
Fix: ignore Markdown links to Jira tickets in smart-commit regex [Issue #159]

### DIFF
--- a/test/unit/smart-commit.test.js
+++ b/test/unit/smart-commit.test.js
@@ -253,6 +253,16 @@ describe('Smart commit parsing', () => {
         issueKeys: ['JRA-090']
       })
     })
+
+    it('should ignore issue keys in a Markdown URL', () => {
+      const text = '[JRA-090](https://mycompany.atlassian.net/browse/JRA-090) JRA-091'
+
+      const result = smartCommit(text)
+
+      expect(result).toMatchObject({
+        issueKeys: ['JRA-091']
+      })
+    })
   })
 
   it('should ignore irrelevant text', () => {


### PR DESCRIPTION
This is to address #159. Note that this is not a complete PR yet, just a failing test for future TDD :)

@tcbyrd What would be the best approach to resolve this? One naive approach I can think of would be adding a negative lookahead or lookbehind for the `atlassian.net` URL to the `issueKeysRegex` in `smart-commit.js`. But this seems brittle and hacky :) Curious to hear your thoughts!