### PR TITLE
Create unique syntax for markdown links

### DIFF
--- a/lib/jira/util/index.js
+++ b/lib/jira/util/index.js
@@ -6,14 +6,18 @@ module.exports = function (jiraClient) {
       ...issueMap,
       [issue.key]: issue
     }), {})
-
     return text.replace(jiraIssueReferenceRegex, (match, issueKey) => {
-      if (!issueMap[issueKey]) {
+      if (!issueMap[issueKey] || isLinkified(match)) {
         return match
       }
       const link = `${jiraClient.baseURL}/browse/${issueKey}`
-      return `[[${issueKey}]](${link})`
+      return `[jira/${issueKey}](${link})`
     })
+  }
+
+  function isLinkified (text) {
+    const markdownLinkRegex = /([*])|\[(.*?)\]\(.*?\)/g
+    return markdownLinkRegex.test(text)
   }
 
   async function unfurl (text) {
@@ -80,6 +84,7 @@ module.exports = function (jiraClient) {
   return {
     addJiraIssueLinks,
     runJiraCommands,
-    unfurl
+    unfurl,
+    isLinkified
   }
 }

--- a/test/safe/issue-comment.test.js
+++ b/test/safe/issue-comment.test.js
@@ -19,7 +19,7 @@ describe('GitHub Actions', () => {
 
         td.verify(githubApi.patch('/repos/test-repo-owner/test-repo-name/issues/comments/test-comment-id', {
           number: 'test-issue-number',
-          body: 'Test example comment with linked Jira issue: [[TEST-123]](https://test-atlassian-instance.net/browse/TEST-123)'
+          body: 'Test example comment with linked Jira issue: [jira/TEST-123](https://test-atlassian-instance.net/browse/TEST-123)'
         }))
       })
     })

--- a/test/safe/issue.test.js
+++ b/test/safe/issue.test.js
@@ -18,7 +18,7 @@ describe('GitHub Actions', () => {
         await app.receive(payload)
 
         td.verify(githubApi.patch('/repos/test-repo-owner/test-repo-name/issues/123456789', {
-          body: 'Test example issue with linked Jira issue: [[TEST-123]](https://test-atlassian-instance.net/browse/TEST-123)',
+          body: 'Test example issue with linked Jira issue: [jira/TEST-123](https://test-atlassian-instance.net/browse/TEST-123)',
           id: 'test-issue-id'
         }))
       })

--- a/test/safe/pull-request.test.js
+++ b/test/safe/pull-request.test.js
@@ -25,7 +25,7 @@ describe('GitHub Actions', () => {
       await app.receive(payload)
 
       td.verify(githubApi.patch('/repos/test-repo-owner/test-repo-name/issues/1', {
-        body: '[[TEST-123]](https://test-atlassian-instance.net/browse/TEST-123) body of the test pull request.',
+        body: '[jira/TEST-123](https://test-atlassian-instance.net/browse/TEST-123) body of the test pull request.',
         id: 'test-pull-request-id'
       }))
 

--- a/test/unit/jira/util.test.js
+++ b/test/unit/jira/util.test.js
@@ -28,7 +28,7 @@ describe('Jira util', () => {
 
       const result = util.addJiraIssueLinks(text, issues)
 
-      expect(result).toBe('Should linkify [[TEST-123]](http://example.com/browse/TEST-123) as a link')
+      expect(result).toBe('Should linkify [jira/TEST-123](http://example.com/browse/TEST-123) as a link')
     })
 
     it('should not linkify Jira references to invalid issues', () => {
@@ -53,7 +53,35 @@ describe('Jira util', () => {
 
       const result = util.addJiraIssueLinks(text, issues)
 
-      expect(result).toBe('Should linkify [[TEST-200]](http://example.com/browse/TEST-200) and not [TEST-100] as a link')
+      expect(result).toBe('Should linkify [jira/TEST-200](http://example.com/browse/TEST-200) and not [TEST-100] as a link')
+    })
+
+    it('should not re-linkify issue keys in a Markdown URL', async () => {
+      const text = '[jira/JRA-090](https://mycompany.atlassian.net/browse/JRA-090)'
+
+      const issues = [
+        {
+          key: 'JRA-090'
+        }
+      ]
+      const result = util.addJiraIssueLinks(text, issues)
+      expect(result).toBe('[jira/JRA-090](https://mycompany.atlassian.net/browse/JRA-090)')
+    })
+
+    it('Still linkifies issue keys outside of markdown links', async () => {
+      const text = '[jira/JRA-090](https://mycompany.atlassian.net/browse/JRA-090) [JRA-091]'
+
+      const issues = [
+        {
+          key: 'JRA-090'
+        },
+        {
+          key: 'JRA-091'
+        }
+      ]
+
+      const result = util.addJiraIssueLinks(text, issues)
+      expect(result).toBe('[jira/JRA-090](https://mycompany.atlassian.net/browse/JRA-090) [jira/JRA-091](http://example.com/browse/JRA-091)')
     })
   })
 


### PR DESCRIPTION
To fix #159 and #141, this PR proposes an alternative unfurl that instead matches how github shortens github links. This also makes it more visually obvious the link will take you to Jira and ensures the rest of the PR body is not effected.

Example:
- Should linkify [TEST-123] as a link. integrations/slack#1

Turns into
- Should linkify [jira/TEST-123](http://example.com/browse/TEST-123) as a link. integrations/slack#1