### PR TITLE
Updates to address sync getting stuck due to invalid issue keys

### DIFF
--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -128,9 +128,8 @@ module.exports.processInstallation = (app, queues) => {
         } catch (err) {
           if (err.response && err.response.status === 400) {
             const errorMessages = err.response && err.response.data && err.response.data.errorMessages
-            app.log(`JIRA Returned ${err.response.status}. Error messages: ${JSON.stringify(errorMessages)}. Payload sent=${jiraPayload}`)
+            app.log.error(`JIRA Returned ${err.response.status}. Error messages: ${JSON.stringify(errorMessages)}. Payload sent=${jiraPayload}`)
           }
-          throw err
         }
       }
       await updateJobStatus(jiraClient, job, edges, task, repositoryId)

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -128,7 +128,7 @@ module.exports.processInstallation = (app, queues) => {
         } catch (err) {
           if (err.response && err.response.status === 400) {
             const errorMessages = err.response && err.response.data && err.response.data.errorMessages
-            app.log.error(`JIRA Returned ${err.response.status}. Error messages: ${JSON.stringify(errorMessages)}. Payload sent=${JSON.stringify(jiraPayload)}`)
+            app.log.error(`JIRA Returned ${err.response.status}. Error messages: ${JSON.stringify(errorMessages)}.`, { jiraPayload })
           }
         }
       }

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -128,7 +128,7 @@ module.exports.processInstallation = (app, queues) => {
         } catch (err) {
           if (err.response && err.response.status === 400) {
             const errorMessages = err.response && err.response.data && err.response.data.errorMessages
-            app.log.error(`JIRA Returned ${err.response.status}. Error messages: ${JSON.stringify(errorMessages)}. Payload sent=${jiraPayload}`)
+            app.log.error(`JIRA Returned ${err.response.status}. Error messages: ${JSON.stringify(errorMessages)}. Payload sent=${JSON.stringify(jiraPayload)}`)
           }
         }
       }

--- a/lib/transforms/smart-commit.js
+++ b/lib/transforms/smart-commit.js
@@ -4,7 +4,7 @@
 // Java brackets equivalents: https://www.regular-expressions.info/posixbrackets.html
 
 const punct = '!"\\#$%&\'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~'
-const issueKeysRegex = new RegExp(`(?:(?<=[\\s${punct}])|^)([A-Z][A-Z\\d_]+-\\d+)(?:(?=[\\s${punct}])|$)`, 'g')
+const issueKeysRegex = new RegExp(`(?:(?<=[\\s${punct}])|^)([A-Z][A-Z\\d]+-\\d+)(?:(?=[\\s${punct}])|$)`, 'g')
 const commandRegex = /(?=#[A-Za-z-]+)/g
 const timeRegex = /((?:(?:\d+[wdhm])\s*)+)\s*/
 

--- a/test/unit/smart-commit.test.js
+++ b/test/unit/smart-commit.test.js
@@ -214,13 +214,13 @@ describe('Smart commit parsing', () => {
       })
     })
 
-    it('should parse an issue key with an underscore and numbers', () => {
+    it('should not parse an issue key with an underscore and numbers', () => {
       const text = 'J_1993A-090'
 
       const result = smartCommit(text)
 
       expect(result).toMatchObject({
-        issueKeys: ['J_1993A-090']
+        issueKeys: undefined
       })
     })
 
@@ -235,7 +235,7 @@ describe('Smart commit parsing', () => {
     })
 
     it('should parse multiple issue keys', () => {
-      const text = 'JRA-090 JRA-091 JRA-092-JRA-093, JRA-094, branchname.JRA-095, branchname_JRA-096, [DEV-4189][DEV-4191] <JRA-123>'
+      const text = 'JRA-090-JRA-091 JRA-092-JRA-093, JRA-094, branchname.JRA-095, branchname_JRA-096, [DEV-4189][DEV-4191] <JRA-123>'
 
       const result = smartCommit(text)
 


### PR DESCRIPTION
The regex we were using to parse Issue Keys is getting false positives against commit messages and PR titles that have an underscore in them.

**Example:**
`JSP_JIR-123` currently matches, but `JSP_JIR` is not a valid identifier according to the devinfo API. I looked through the logs from sync jobs that were getting this error and none of them looked like valid Jira issue keys.

To verify, I tried creating an issue key with underscores, but Jira will not allow this:

<img src="https://user-images.githubusercontent.com/13207348/50794055-0cc3d380-1298-11e9-8528-a83471aa50ab.png" width="400" />

This PR prevents the integration from matching on those keys. In addition, it will no longer throw when it encounters a bad request. Instead, it will just log an error and continue on to the next page of results. This will allow the sync to continue while allowing for further diagnostics.