### PR TITLE
Handle deleted users that were authors of a PR

### DIFF
--- a/lib/sync/transforms/pull-request.js
+++ b/lib/sync/transforms/pull-request.js
@@ -15,7 +15,7 @@ function mapStatus ({ state, merged }) {
 }
 
 function getAuthor (author) {
-  //if author is null, return the ghost user
+  // If author is null, return the ghost user
   if (!author) {
     return {
       avatar: 'https://github.com/ghost.png',
@@ -23,7 +23,7 @@ function getAuthor (author) {
       url: 'https://github.com/ghost'
     }
   }
-  
+
   return {
     avatar: author.avatarUrl,
     name: author.login,

--- a/lib/sync/transforms/pull-request.js
+++ b/lib/sync/transforms/pull-request.js
@@ -14,6 +14,22 @@ function mapStatus ({ state, merged }) {
   }
 }
 
+function getAuthor (author) {
+  //if author is null, return the ghost user
+  if (!author) {
+    return {
+      avatar: 'https://github.com/ghost.png',
+      name: 'Deleted User',
+      url: 'https://github.com/ghost'
+    }
+  }
+  
+  return {
+    avatar: author.avatarUrl,
+    name: author.login,
+    url: author.url
+  }
+}
 module.exports = (payload, author) => {
   // eslint-disable-next-line camelcase
   const { pull_request: pullRequest, repository } = payload
@@ -29,11 +45,7 @@ module.exports = (payload, author) => {
       name: repository.full_name,
       pullRequests: [
         {
-          author: {
-            avatar: author.avatarUrl,
-            name: author.login,
-            url: author.url
-          },
+          author: getAuthor(author),
           commentCount: pullRequest.comments.totalCount,
           destinationBranch: `${repository.html_url}/tree/${pullRequest.baseRef ? pullRequest.baseRef.name : ''}`,
           displayId: `#${pullRequest.number}`,

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -32,13 +32,13 @@ Object.keys(queues).forEach(name => {
 
   queue.on('failed', async (job, err) => {
     app.log.error({ job, err, queue: name })
-    const subscription = await Subscription.getSingleInstallation(job.jiraHost, job.installationId)
+    const subscription = await Subscription.getSingleInstallation(job.data.jiraHost, job.data.installationId)
     await subscription.set('syncStatus', 'FAILED')
   })
 })
 
 const migrateJob = job => {
-  const { installationId, jiraHost } = job
+  const { installationId, jiraHost } = job.data
   queues.installation.add({ installationId, jiraHost })
 }
 

--- a/test/unit/sync/transforms/pull-request.test.js
+++ b/test/unit/sync/transforms/pull-request.test.js
@@ -1,0 +1,110 @@
+const transformPullRequest = require('../../../../lib/sync/transforms/pull-request')
+
+describe('pull_request transform', () => {
+  it('should send the ghost user to Jira when GitHub user has been deleted', () => {
+    const payload = {
+      pull_request: {
+        author: null, // GraphQL returns `null` when author of PR has been deleted from GitHub
+        databaseId: 1234568,
+        comments: {
+          totalCount: 1
+        },
+        repository: {
+          url: 'https://github.com/test-owner/test-repo'
+        },
+        baseRef: {
+          name: 'master'
+        },
+        headRef: {
+          name: 'test-branch'
+        },
+        number: 123,
+        state: 'MERGED',
+        title: 'TES-123 Test Pull Request title',
+        body: '',
+        updatedAt: '2018-04-18T15:42:13Z',
+        url: 'https://github.com/test-owner/test-repo/pull/123'
+      },
+      repository: {
+        id: 1234568,
+        name: 'test-repo',
+        full_name: 'test-owner/test-repo',
+        owner: { login: 'test-login' },
+        html_url: 'https://github.com/test-owner/test-repo'
+      }
+    }
+    
+    Date.now = jest.fn(() => 12345678)
+
+    const { data } = transformPullRequest(payload, payload.pull_request.author)
+    expect(data).toMatchObject({
+      id: 1234568,
+      name: 'test-owner/test-repo',
+      pullRequests: [
+        {
+          // 'ghost' is a special user GitHub associates with
+          // comments/PRs when a user deletes their account
+          author: {
+            avatar: 'https://github.com/ghost.png',
+            name: 'Deleted User',
+            url: 'https://github.com/ghost'
+          },
+          commentCount: 1,
+          destinationBranch: 'https://github.com/test-owner/test-repo/tree/master',
+          displayId: '#123',
+          id: 123,
+          issueKeys: ['TES-123'],
+          lastUpdate: '2018-04-18T15:42:13Z',
+          sourceBranch: 'test-branch',
+          sourceBranchUrl: 'https://github.com/test-owner/test-repo/tree/test-branch',
+          status: 'MERGED',
+          timestamp: '2018-04-18T15:42:13Z',
+          title: 'TES-123 Test Pull Request title',
+          url: 'https://github.com/test-owner/test-repo/pull/123',
+          updateSequenceId: 12345678
+        }
+      ],
+      url: 'https://github.com/test-owner/test-repo',
+      updateSequenceId: 12345678
+    })
+  })
+
+  it('should return no data if there are no issue keys', () => {
+    const payload = {
+      pull_request: {
+        author: null,
+        databaseId: 1234568,
+        comments: {
+          totalCount: 1
+        },
+        repository: {
+          url: 'https://github.com/test-owner/test-repo'
+        },
+        baseRef: {
+          name: 'master'
+        },
+        headRef: {
+          name: 'test-branch'
+        },
+        number: 123,
+        state: 'MERGED',
+        title: 'Test Pull Request title',
+        body: '',
+        updatedAt: '2018-04-18T15:42:13Z',
+        url: 'https://github.com/test-owner/test-repo/pull/123'
+      },
+      repository: {
+        id: 1234568,
+        name: 'test-repo',
+        full_name: 'test-owner/test-repo',
+        owner: { login: 'test-login' },
+        html_url: 'https://github.com/test-owner/test-repo'
+      }
+    }
+
+    Date.now = jest.fn(() => 12345678)
+
+    const { data } = transformPullRequest(payload, payload.pull_request.author)
+    expect(data).toBeUndefined()
+  })
+})

--- a/test/unit/sync/transforms/pull-request.test.js
+++ b/test/unit/sync/transforms/pull-request.test.js
@@ -33,7 +33,7 @@ describe('pull_request transform', () => {
         html_url: 'https://github.com/test-owner/test-repo'
       }
     }
-    
+
     Date.now = jest.fn(() => 12345678)
 
     const { data } = transformPullRequest(payload, payload.pull_request.author)


### PR DESCRIPTION
In the REST API, we return the [Ghost User](https://github.com/ghost) when a user that's an author of a PR deletes their account. In GraphQL we handle this by returning `null`, which is causing syncs of Pull Requests to fail since we expect properties to be returned on the `avatar` object. The Devinfo API [requires at least an author name](https://github.com/integrations/jira/blob/053cc76af05ea045d964b7fd1634473534aa9bb1/docs/jira-dev-info-0.10-swagger.yaml#L395-L398) to be sent over with the PR object, so this will just return the ghost user info when GraphQL returns `null` for author.