### PR TITLE
[WIP] Adding datadog live process monitoring

### DIFF
--- a/datadog/conf.d/datadog.yaml
+++ b/datadog/conf.d/datadog.yaml
@@ -1,0 +1,2 @@
+process_config:
+  enabled: "true"


### PR DESCRIPTION
We're currently only sending Heroku host level information to Datadog. This updates the datadog agent config to use [Live Process monitoring](https://docs.datadoghq.com/graphing/infrastructure/process/?tab=linuxwindows) as well. I'm not clear if this feature is enabled on our DD infrastructure, so going to deploy this to staging first to see if it shows up.