### PR TITLE
Delete old queues

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -15,9 +15,6 @@ const { Subscription } = require('../models')
 // Setup queues
 const queues = {
   discovery: new Queue('Content discovery', REDIS_URL),
-  pullRequests: new Queue('Pull Requests transformation', REDIS_URL),
-  commits: new Queue('Commit transformation', REDIS_URL),
-  branches: new Queue('Branch transformation', REDIS_URL),
   installation: new Queue('Initial sync', REDIS_URL),
   push: new Queue('Push transformation', REDIS_URL)
 }
@@ -37,18 +34,10 @@ Object.keys(queues).forEach(name => {
   })
 })
 
-const migrateJob = job => {
-  const { installationId, jiraHost } = job.data
-  queues.installation.add({ installationId, jiraHost })
-}
-
 module.exports = {
   queues,
 
   start () {
-    queues.pullRequests.process(1, migrateJob)
-    queues.commits.process(1, migrateJob)
-    queues.branches.process(1, migrateJob)
     queues.discovery.process(5, discovery(app, queues))
     queues.installation.process(Number(CONCURRENT_WORKERS), processInstallation(app, queues))
     queues.push.process(Number(CONCURRENT_WORKERS), limiterPerInstallation(processPush(app)))
@@ -59,12 +48,6 @@ module.exports = {
     return Promise.all([
       queues.discovery.clean(10000, 'completed'),
       queues.discovery.clean(10000, 'failed'),
-      queues.pullRequests.clean(10000, 'completed'),
-      queues.pullRequests.clean(10000, 'failed'),
-      queues.commits.clean(10000, 'completed'),
-      queues.commits.clean(10000, 'failed'),
-      queues.branches.clean(10000, 'completed'),
-      queues.branches.clean(10000, 'failed'),
       queues.installation.clean(10000, 'completed'),
       queues.installation.clean(10000, 'failed'),
       queues.push.clean(10000, 'completed'),
@@ -74,9 +57,6 @@ module.exports = {
 
   async stop () {
     return Promise.all([
-      queues.pullRequests.close(),
-      queues.commits.close(),
-      queues.branches.close(),
       queues.discovery.close(),
       queues.installation.close(),
       queues.push.close()


### PR DESCRIPTION
The jobs in these queues were migrated and processed in the `installation` queue and no new jobs are stored in there. So we don't need to keep them in the code.