### PR TITLE
Find issue keys in branch names when opening PRs

### DIFF
--- a/lib/transforms/pull-request.js
+++ b/lib/transforms/pull-request.js
@@ -18,7 +18,7 @@ function mapStatus ({ state, merged }) {
 module.exports = (payload, author) => {
   // eslint-disable-next-line camelcase
   const { pull_request, repository } = payload
-  const { issueKeys } = parseSmartCommit(pull_request.title)
+  const { issueKeys } = parseSmartCommit(pull_request.title + '\n' + pull_request.head.ref)
 
   if (!issueKeys || !pull_request.head.repo) {
     return { data: undefined }

--- a/test/fixtures/pull-request-basic.json
+++ b/test/fixtures/pull-request-basic.json
@@ -23,7 +23,7 @@
         "repo": {
           "html_url": "test-pull-request-head-url"
         },
-        "ref": "test-pull-request-head-ref",
+        "ref": "TEST-321-test-pull-request-head-ref",
         "sha": "test-pull-request-sha"
       },
       "base": {

--- a/test/safe/pull-request.test.js
+++ b/test/safe/pull-request.test.js
@@ -38,23 +38,25 @@ describe('GitHub Actions', () => {
             id: 'test-repo-id',
             branches: [
               {
-                createPullRequestUrl: 'test-pull-request-head-url/pull/new/test-pull-request-head-ref',
+                createPullRequestUrl: 'test-pull-request-head-url/pull/new/TEST-321-test-pull-request-head-ref',
                 lastCommit: {
-                  author: {name: 'test-pull-request-author-login'},
+                  author: {
+                    name: 'test-pull-request-author-login'
+                  },
                   authorTimestamp: 'test-pull-request-update-time',
                   displayId: 'test-p',
                   fileCount: 0,
                   hash: 'test-pull-request-sha',
                   id: 'test-pull-request-sha',
-                  issueKeys: ['TEST-123'],
+                  issueKeys: ['TEST-123', 'TEST-321'],
                   message: 'n/a',
                   updateSequenceId: 12345678,
                   url: 'test-pull-request-head-url/commit/test-pull-request-sha'
                 },
-                id: 'test-pull-request-head-ref',
-                issueKeys: ['TEST-123'],
-                name: 'test-pull-request-head-ref',
-                url: 'test-pull-request-head-url/tree/test-pull-request-head-ref',
+                id: 'TEST-321-test-pull-request-head-ref',
+                issueKeys: ['TEST-123', 'TEST-321'],
+                name: 'TEST-321-test-pull-request-head-ref',
+                url: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
                 updateSequenceId: 12345678
               }
             ],
@@ -69,10 +71,10 @@ describe('GitHub Actions', () => {
                 destinationBranch: 'test-pull-request-base-url/tree/test-pull-request-base-ref',
                 displayId: '#1',
                 id: 1,
-                issueKeys: ['TEST-123'],
+                issueKeys: ['TEST-123', 'TEST-321'],
                 lastUpdate: 'test-pull-request-update-time',
-                sourceBranch: 'test-pull-request-head-ref',
-                sourceBranchUrl: 'test-pull-request-head-url/tree/test-pull-request-head-ref',
+                sourceBranch: 'TEST-321-test-pull-request-head-ref',
+                sourceBranchUrl: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
                 status: 'OPEN',
                 title: '[TEST-123] Test pull request.',
                 timestamp: 'test-pull-request-update-time',


### PR DESCRIPTION
Have into account also the branch name since GitHub sometimes humanizes the PR title based on the branch name by default and the issue key is lost that way. So, using the branch name should keep that issue key reference.

cc https://github.com/github/ecosystem-primitives/issues/145