### PR TITLE
Reduce production logging

### DIFF
--- a/db/config.json
+++ b/db/config.json
@@ -14,6 +14,7 @@
   "production": {
     "dialect": "postgres",
     "use_env_variable": "DATABASE_URL",
+    "disable_sql_logging": true,
     "operatorsAliases": false,
     "ssl": true,
     "dialectOptions": {

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -7,12 +7,14 @@ const InstallationModel = require('./installation')
 const SubscriptionModel = require('./subscription')
 const ProjectModel = require('./project')
 
+const logging = config.disable_sql_logging
+  ? undefined
+  : (query, ms) => logger.debug({ ms }, query)
+
 Object.assign(config, {
   operatorsAliases: false,
   benchmark: true,
-  logging: (query, ms) => {
-    logger.debug({ ms }, query)
-  }
+  logging
 })
 
 let sequelize


### PR DESCRIPTION
cc https://github.com/github/ecosystem-primitives/issues/139

In order to reduce the volume of logs this PR disables logging SQL queries in production.

We've done the same in the Slack integration https://github.com/integrations/slack/pull/803