### PR TITLE
Jira timeout

### DIFF
--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -109,7 +109,8 @@ function getExpirationInSeconds () {
  */
 module.exports = (id, installationId, baseURL, secret) => {
   const instance = axios.create({
-    baseURL
+    baseURL,
+    timeout: +process.env.JIRA_TIMEOUT || 20000
   })
 
   instance.interceptors.request.use(getAuthMiddleware(secret))


### PR DESCRIPTION
Specify a timeout for the requests to JIRA to prevent us timing out and not even being able to show a custom error page to the user.

Axios by default doesn't have a timeout https://github.com/axios/axios