### PR TITLE
Feature: Handle payloads where issue keys are removed

### DIFF
--- a/lib/github/pull-request.js
+++ b/lib/github/pull-request.js
@@ -1,11 +1,19 @@
 const { Project } = require('../models')
 const transformPullRequest = require('../transforms/pull-request')
 const reduceProjectKeys = require('../jira/util/reduce-project-keys')
+const parseSmartCommit = require('../transforms/smart-commit')
 
 module.exports = async (context, jiraClient, util) => {
   const author = await context.github.users.getForUser({ username: context.payload.pull_request.user.login })
   const { data: jiraPayload } = transformPullRequest(context.payload, author.data)
   const { pull_request: pullRequest } = context.payload
+
+  if (!jiraPayload && context.payload.changes) {
+    const hasIssueKeys = !!parseSmartCommit(context.payload.changes.title.from)
+    if (hasIssueKeys) {
+      return jiraClient.devinfo.pullRequest.delete(context.payload.repository.id, pullRequest.number)
+    }
+  }
 
   const linkifiedBody = await util.unfurl(pullRequest.body)
   if (linkifiedBody) {

--- a/lib/github/pull-request.js
+++ b/lib/github/pull-request.js
@@ -8,7 +8,7 @@ module.exports = async (context, jiraClient, util) => {
   const { data: jiraPayload } = transformPullRequest(context.payload, author.data)
   const { pull_request: pullRequest } = context.payload
 
-  if (!jiraPayload && context.payload.changes) {
+  if (!jiraPayload && (context.payload.changes && context.payload.changes.title)) {
     const hasIssueKeys = !!parseSmartCommit(context.payload.changes.title.from)
     if (hasIssueKeys) {
       return jiraClient.devinfo.pullRequest.delete(context.payload.repository.id, pullRequest.number)

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -97,6 +97,11 @@ module.exports = async (id, installationId, jiraHost) => {
         complete: () => instance.post('/rest/devinfo/0.10/github/migrationComplete', {}),
         undo: () => instance.post('/rest/devinfo/0.10/github/undoMigration', {})
       },
+      pullRequest: {
+        delete: (repositoryId, number) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}/pull_request/${number}`, {
+          fields: { _updateSequenceId: Date.now() }
+        })
+      },
       repository: {
         get: (repositoryId) => instance.get(`/rest/devinfo/0.10/repository/${repositoryId}`),
         delete: (repositoryId) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}`, {

--- a/lib/sync/transforms/pull-request.js
+++ b/lib/sync/transforms/pull-request.js
@@ -30,6 +30,7 @@ function getAuthor (author) {
     url: author.url
   }
 }
+
 module.exports = (payload, author) => {
   // eslint-disable-next-line camelcase
   const { pull_request: pullRequest, repository } = payload

--- a/test/fixtures/pull-request-remove-keys.json
+++ b/test/fixtures/pull-request-remove-keys.json
@@ -1,0 +1,34 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "edited",
+    "number": 104,
+    "pull_request": {
+      "number": 104,
+      "state": "open",
+      "locked": false,
+      "title": "Testing a deleted user",
+      "head": {
+        "ref": "test-ref"
+      },
+      "user": {
+        "login": "test-user"
+      }
+    },
+    "changes": {
+      "title": {
+        "from": "[TES-123] Testing a deleted user"
+      }
+    },
+    "repository": {
+      "id": 78124909,
+      "private": true
+    },
+    "sender": {
+      "type": "User"
+    },
+    "installation": {
+      "id": "test-installation-id"
+    }
+  }
+}

--- a/test/fixtures/pull-request-remove-keys.json
+++ b/test/fixtures/pull-request-remove-keys.json
@@ -1,31 +1,50 @@
 {
   "name": "pull_request",
   "payload": {
-    "action": "edited",
-    "number": 104,
-    "pull_request": {
-      "number": 104,
-      "state": "open",
-      "locked": false,
-      "title": "Testing a deleted user",
-      "head": {
-        "ref": "test-ref"
-      },
-      "user": {
-        "login": "test-user"
+    "action": "opened",
+    "repository": {
+      "id": "test-repo-id",
+      "name": "test-repo-name",
+      "full_name": "example/test-repo-name",
+      "html_url": "test-repo-url",
+      "owner": {
+        "login": "test-repo-owner"
       }
     },
     "changes": {
       "title": {
-        "from": "[TES-123] Testing a deleted user"
+        "from": "TES-3 test"
       }
     },
-    "repository": {
-      "id": 78124909,
-      "private": true
+    "pull_request": {
+      "id": "test-pull-request-id",
+      "number": 1,
+      "state": "open",
+      "title": "Test pull request.",
+      "body": "body of the test pull request.",
+      "comments": "test-pull-request-comment-count",
+      "html_url": "test-pull-request-url",
+      "head": {
+        "repo": {
+          "html_url": "test-pull-request-head-url"
+        },
+        "ref": "test-pull-request-head-ref",
+        "sha": "test-pull-request-sha"
+      },
+      "base": {
+        "repo": {
+          "html_url": "test-pull-request-base-url"
+        },
+        "ref": "test-pull-request-base-ref"
+      },
+      "user": {
+        "login": "test-pull-request-user-login"
+      },
+      "updated_at": "test-pull-request-update-time"
     },
     "sender": {
-      "type": "User"
+      "type": "User",
+      "login": "TestUser"
     },
     "installation": {
       "id": "test-installation-id"

--- a/test/fixtures/pull-request-test-changes-with-branch.json
+++ b/test/fixtures/pull-request-test-changes-with-branch.json
@@ -1,0 +1,53 @@
+{
+  "name": "pull_request",
+  "payload": {
+    "action": "opened",
+    "repository": {
+      "id": "test-repo-id",
+      "name": "test-repo-name",
+      "full_name": "example/test-repo-name",
+      "html_url": "test-repo-url",
+      "owner": {
+        "login": "test-repo-owner"
+      }
+    },
+    "changes": {
+      "title": {
+        "from": "TES-3 test"
+      }
+    },
+    "pull_request": {
+      "id": "test-pull-request-id",
+      "number": 1,
+      "state": "open",
+      "title": "Test pull request.",
+      "body": "body of the test pull request.",
+      "comments": "test-pull-request-comment-count",
+      "html_url": "test-pull-request-url",
+      "head": {
+        "repo": {
+          "html_url": "TES-3-test-pull-request-head-url"
+        },
+        "ref": "TES-3-test-pull-request-head-ref",
+        "sha": "test-pull-request-sha"
+      },
+      "base": {
+        "repo": {
+          "html_url": "test-pull-request-base-url"
+        },
+        "ref": "pull-request-base-ref"
+      },
+      "user": {
+        "login": "test-pull-request-user-login"
+      },
+      "updated_at": "test-pull-request-update-time"
+    },
+    "sender": {
+      "type": "User",
+      "login": "TestUser"
+    },
+    "installation": {
+      "id": "test-installation-id"
+    }
+  }
+}

--- a/test/safe/pull-request.test.js
+++ b/test/safe/pull-request.test.js
@@ -129,7 +129,7 @@ describe('GitHub Actions', () => {
 
     it('will not delete references if a branch still has an issue key', async () => {
       const payload = require('../fixtures/pull-request-test-changes-with-branch.json')
-      
+
       const jiraApi = td.api('https://test-atlassian-instance.net')
       const githubApi = td.api('https://api.github.com')
 
@@ -142,62 +142,62 @@ describe('GitHub Actions', () => {
       Date.now = jest.fn(() => 12345678)
 
       await app.receive(payload)
-      
+
       td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
         preventTransitions: false,
         repositories: [
           {
-            id: "test-repo-id",
-            name: "example/test-repo-name",
-            url: "test-repo-url",
+            id: 'test-repo-id',
+            name: 'example/test-repo-name',
+            url: 'test-repo-url',
             branches: [
               {
-                createPullRequestUrl: "TES-3-test-pull-request-head-url/pull/new/TES-3-test-pull-request-head-ref",
+                createPullRequestUrl: 'TES-3-test-pull-request-head-url/pull/new/TES-3-test-pull-request-head-ref',
                 lastCommit: {
-                  author: {name: "test-pull-request-author-login"},
-                  authorTimestamp: "test-pull-request-update-time",
-                  displayId: "test-p",
+                  author: {name: 'test-pull-request-author-login'},
+                  authorTimestamp: 'test-pull-request-update-time',
+                  displayId: 'test-p',
                   fileCount: 0,
-                  hash: "test-pull-request-sha",
-                  id: "test-pull-request-sha",
-                  issueKeys: ["TES-3"],
-                  message: "n/a",
+                  hash: 'test-pull-request-sha',
+                  id: 'test-pull-request-sha',
+                  issueKeys: ['TES-3'],
+                  message: 'n/a',
                   updateSequenceId: 12345678,
-                  url: "TES-3-test-pull-request-head-url/commit/test-pull-request-sha"
+                  url: 'TES-3-test-pull-request-head-url/commit/test-pull-request-sha'
                 },
-                id: "TES-3-test-pull-request-head-ref",
-                issueKeys: ["TES-3"],
-                name: "TES-3-test-pull-request-head-ref",
-                url: "TES-3-test-pull-request-head-url/tree/TES-3-test-pull-request-head-ref",
+                id: 'TES-3-test-pull-request-head-ref',
+                issueKeys: ['TES-3'],
+                name: 'TES-3-test-pull-request-head-ref',
+                url: 'TES-3-test-pull-request-head-url/tree/TES-3-test-pull-request-head-ref',
                 updateSequenceId: 12345678
               }
             ],
             pullRequests: [
               {
                 author: {
-                  avatar: "test-pull-request-author-avatar",
-                  name: "test-pull-request-author-login",
-                  url: "test-pull-request-author-url"
+                  avatar: 'test-pull-request-author-avatar',
+                  name: 'test-pull-request-author-login',
+                  url: 'test-pull-request-author-url'
                 },
-                commentCount: "test-pull-request-comment-count",
-                destinationBranch: "test-pull-request-base-url/tree/pull-request-base-ref",
-                displayId: "#1",
+                commentCount: 'test-pull-request-comment-count',
+                destinationBranch: 'test-pull-request-base-url/tree/pull-request-base-ref',
+                displayId: '#1',
                 id: 1,
-                issueKeys: ["TES-3"],
-                lastUpdate: "test-pull-request-update-time",
-                sourceBranch: "TES-3-test-pull-request-head-ref",
-                sourceBranchUrl: "TES-3-test-pull-request-head-url/tree/TES-3-test-pull-request-head-ref",
-                status: "OPEN",
-                timestamp: "test-pull-request-update-time",
-                title: "Test pull request.",
-                url: "test-pull-request-url",
+                issueKeys: ['TES-3'],
+                lastUpdate: 'test-pull-request-update-time',
+                sourceBranch: 'TES-3-test-pull-request-head-ref',
+                sourceBranchUrl: 'TES-3-test-pull-request-head-url/tree/TES-3-test-pull-request-head-ref',
+                status: 'OPEN',
+                timestamp: 'test-pull-request-update-time',
+                title: 'Test pull request.',
+                url: 'test-pull-request-url',
                 updateSequenceId: 12345678
               }
             ],
             updateSequenceId: 12345678
           }
         ],
-        properties: {installationId: "test-installation-id"}
+        properties: {installationId: 'test-installation-id'}
       }))
     })
   })

--- a/test/safe/pull-request.test.js
+++ b/test/safe/pull-request.test.js
@@ -107,5 +107,24 @@ describe('GitHub Actions', () => {
       // should not throw
       await app.receive(payload)
     })
+
+    it('should delete the reference to a pull request when issue keys are removed from the title', async () => {
+      const payload = require('../fixtures/pull-request-remove-keys.json')
+      const { repository, pull_request: pullRequest } = payload.payload
+      const githubApi = td.api('https://api.github.com')
+      const jiraApi = td.api('https://test-atlassian-instance.net')
+
+      td.when(githubApi.get('/users/test-pull-request-user-login')).thenReturn({
+        login: 'test-pull-request-author-login',
+        avatar_url: 'test-pull-request-author-avatar',
+        html_url: 'test-pull-request-author-url'
+      })
+
+      Date.now = jest.fn(() => 12345678)
+
+      await app.receive(payload)
+
+      td.verify(jiraApi.delete(`/rest/devinfo/0.10/repository/${repository.id}/pull_request/${pullRequest.number}?_updateSequenceId=12345678`))
+    })
   })
 })

--- a/test/safe/pull-request.test.js
+++ b/test/safe/pull-request.test.js
@@ -126,5 +126,79 @@ describe('GitHub Actions', () => {
 
       td.verify(jiraApi.delete(`/rest/devinfo/0.10/repository/${repository.id}/pull_request/${pullRequest.number}?_updateSequenceId=12345678`))
     })
+
+    it('will not delete references if a branch still has an issue key', async () => {
+      const payload = require('../fixtures/pull-request-test-changes-with-branch.json')
+      
+      const jiraApi = td.api('https://test-atlassian-instance.net')
+      const githubApi = td.api('https://api.github.com')
+
+      td.when(githubApi.get('/users/test-pull-request-user-login')).thenReturn({
+        login: 'test-pull-request-author-login',
+        avatar_url: 'test-pull-request-author-avatar',
+        html_url: 'test-pull-request-author-url'
+      })
+
+      Date.now = jest.fn(() => 12345678)
+
+      await app.receive(payload)
+      
+      td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
+        preventTransitions: false,
+        repositories: [
+          {
+            id: "test-repo-id",
+            name: "example/test-repo-name",
+            url: "test-repo-url",
+            branches: [
+              {
+                createPullRequestUrl: "TES-3-test-pull-request-head-url/pull/new/TES-3-test-pull-request-head-ref",
+                lastCommit: {
+                  author: {name: "test-pull-request-author-login"},
+                  authorTimestamp: "test-pull-request-update-time",
+                  displayId: "test-p",
+                  fileCount: 0,
+                  hash: "test-pull-request-sha",
+                  id: "test-pull-request-sha",
+                  issueKeys: ["TES-3"],
+                  message: "n/a",
+                  updateSequenceId: 12345678,
+                  url: "TES-3-test-pull-request-head-url/commit/test-pull-request-sha"
+                },
+                id: "TES-3-test-pull-request-head-ref",
+                issueKeys: ["TES-3"],
+                name: "TES-3-test-pull-request-head-ref",
+                url: "TES-3-test-pull-request-head-url/tree/TES-3-test-pull-request-head-ref",
+                updateSequenceId: 12345678
+              }
+            ],
+            pullRequests: [
+              {
+                author: {
+                  avatar: "test-pull-request-author-avatar",
+                  name: "test-pull-request-author-login",
+                  url: "test-pull-request-author-url"
+                },
+                commentCount: "test-pull-request-comment-count",
+                destinationBranch: "test-pull-request-base-url/tree/pull-request-base-ref",
+                displayId: "#1",
+                id: 1,
+                issueKeys: ["TES-3"],
+                lastUpdate: "test-pull-request-update-time",
+                sourceBranch: "TES-3-test-pull-request-head-ref",
+                sourceBranchUrl: "TES-3-test-pull-request-head-url/tree/TES-3-test-pull-request-head-ref",
+                status: "OPEN",
+                timestamp: "test-pull-request-update-time",
+                title: "Test pull request.",
+                url: "test-pull-request-url",
+                updateSequenceId: 12345678
+              }
+            ],
+            updateSequenceId: 12345678
+          }
+        ],
+        properties: {installationId: "test-installation-id"}
+      }))
+    })
   })
 })


### PR DESCRIPTION
On Pull Requests, a user can freely edit the title to contain issue keys ore remove them. Right now if you update the Issue Key, the Jira API will automatically move the PR from one issue to another. But if you remove all issue keys, we stop processing the payload since it doesn't contain smart commit data. This PR adds a feature that will delete the Pull Request from Jira if you remove the issue key from the title by parsing the `payload.changes` hash, which contains the title that the PR was changed _from_. We don't need to know the issue keys to delete it from Jira. We just tell the Jira API to delete the reference to the Pull Request.