### PR TITLE
Add GDPR flag to connect descriptor

### DIFF
--- a/lib/jira/connect.js
+++ b/lib/jira/connect.js
@@ -6,6 +6,11 @@ module.exports = async (req, res) => {
 
   return res.status(200)
     .json({
+      // Will need to be set to `true` once we verify the app will work with
+      // GDPR compliant APIs. Ref: https://github.com/github/ecosystem-primitives/issues/220
+      apiMigrations: {
+        gdpr: false
+      },
       name: 'GitHub' + (isProd ? '' : (instance ? (` (${instance})`) : '')),
       description: 'Application for integrating with GitHub',
       key: 'com.github.integration' + (instance ? `.${instance}` : ''),


### PR DESCRIPTION
First step listed in https://developer.atlassian.com/blog/2019/02/app-opt-in-api-migration/ is to signal we'll be testing our app for GDPR compliant API migration by setting `gdpr: false`. This adds that descriptor.