### PR TITLE
Add Full resync option

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -37,19 +37,18 @@ You can check your sync status in the integration settings:
 | ACTIVE   | The sync has started and is still in progress. No information will be displayed in Jira. |
 | COMPLETE | The sync has finished. Information will be displayed in Jira. |
 
-The sync should take a maximum of ~5 hours. If your sync status is still `ACTIVE` after 5 hours:
+The time it takes to complete the sync will depend on the size of your installation. Since the sync scans commits for every repository in your installation, be mindful that selecting "All Repositories" will perform a scan of every repository in your account, including forks. If you have repositories with hundreds of thousands of forks (e.g. a fork of the Linux repo), the scan might take several hours to complete.
 
-1. Open the integration settings: **Jira Settings** -> **Add-ons** -> **Manage Add-ons** -> **GitHub** -> **Get started**
-2. Click the **Retry** button
-
-If after another 5 hours your status is still not `COMPLETE`, try selecting just the repositories that Jira needs access to:
+Because everyone's repository histories are different, it's difficult to determine how long the scan should take for a specific installation, but on aveage the sync can process around 100 commits per second. If it's still stuck in `ACTIVE` after a few hours, please check your installation for any large repositories first and attempt a full re-sync:
 
 1. Open the GitHub Apps settings in GitHub.
-2. Click **Configure** on Jira.
-3. In Repository access, select only the repositories that Jira needs access to
+2. Click **Configure** in Jira.
+3. In Repository access, select only the repositories you with to sync to Jira.
 4. Click **Save**
+5. Open the integration settings: **Jira Settings** -> **Add-ons** -> **Manage Add-ons** -> **GitHub** -> **Get started**
+6. Under **Retry**, click the dropdown and select "Full", then click **Submit**
 
-This will automatically start a new sync.
+This will rediscover all repositories in your installation and start a new sync.
 
 Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -141,12 +141,15 @@ app.get('/:installationId', async (req, res) => {
 
 app.get('/:installationId/repoSyncState.json', async (req, res) => {
   const { Subscription } = require('../models')
+  const { installationId } = req.params
+  const { jiraHost } = req.query
+
   try {
-    const subscriptions = await Subscription.getAllForInstallation(req.params.installationId)
-    if (!subscriptions.length) {
+    const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
+    if (!subscription) {
       return res.sendStatus(404)
     }
-    const data = subscriptions[0].dataValues.repoSyncState
+    const data = subscription.dataValues.repoSyncState
     return res.json(data)
   } catch (err) {
     res.status(500)
@@ -157,15 +160,18 @@ app.get('/:installationId/repoSyncState.json', async (req, res) => {
 app.post('/:installationId/sync', bodyParser, async (req, res) => {
   const { Subscription } = require('../models')
   const { installationId } = req.params
+  console.log(req.body)
   const { jiraHost } = req.body
 
   try {
+    console.log(jiraHost, installationId)
     const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
     if (!subscription) {
       return res.sendStatus(404)
     }
 
-    await Subscription.findOrStartSync(subscription)
+    const type = req.body.resetType || null
+    await Subscription.findOrStartSync(subscription, type)
 
     res.status(202)
     return res.json({

--- a/lib/frontend/retry-sync.js
+++ b/lib/frontend/retry-sync.js
@@ -2,7 +2,7 @@ const { Installation, Subscription } = require('../models')
 const jwt = require('atlassian-jwt')
 
 module.exports = async (req, res, next) => {
-  const { jiraHost, installationId, token } = req.body
+  const { jiraHost, installationId, token, syncType } = req.body
 
   const installation = await Installation.getForHost(jiraHost)
 
@@ -14,7 +14,7 @@ module.exports = async (req, res, next) => {
 
       const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
 
-      await Subscription.findOrStartSync(subscription)
+      await Subscription.findOrStartSync(subscription, syncType)
 
       return res.sendStatus(202)
     } catch (error) {

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -61,7 +61,7 @@ module.exports = class Subscription extends Sequelize.Model {
     })
   }
 
-  static async findOrStartSync (subscription) {
+  static async findOrStartSync (subscription, syncType) {
     const { gitHubInstallationId: installationId, jiraHost } = subscription
     const { queues } = require('../worker')
 
@@ -69,7 +69,7 @@ module.exports = class Subscription extends Sequelize.Model {
 
     // If repo sync state is empty
     // start a sync job from scratch
-    if (!repoSyncState) {
+    if (!repoSyncState || (syncType === 'full')) {
       await subscription.update({
         syncStatus: 'PENDING',
         repoSyncState: {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -36,3 +36,46 @@
   background: #d04437;
   color: #fff;
 }
+
+.sync-modal {
+  display: none;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);
+}
+
+.sync-modal-btn {
+  cursor: pointer;
+  font-size: 14px;
+  position: relative;
+  top: 1px;
+}
+
+.sync-modal-content {
+  background-color: #fefefe;
+  margin: 15% auto;
+  padding: 10px;
+  border: 1px solid #888;
+  width: 80%;
+}
+
+.close {
+  color: #aaa;
+  float: right;
+  top: 5px;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
+}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -37,7 +37,7 @@
   color: #fff;
 }
 
-.sync-modal {
+.sync-retry-modal {
   display: none;
   position: fixed;
   z-index: 1;
@@ -50,14 +50,21 @@
   background-color: rgba(0,0,0,0.4);
 }
 
-.sync-modal-btn {
+.sync-retry-modal-btn {
   cursor: pointer;
   font-size: 14px;
   position: relative;
   top: 1px;
 }
 
-.sync-modal-content {
+.sync-status-modal-btn {
+  cursor: pointer;
+  font-size: 14px;
+  position: relative;
+  top: 1px;
+}
+
+.sync-retry-modal-content {
   background-color: #fefefe;
   margin: 15% auto;
   padding: 10px;

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -55,6 +55,7 @@ $('.sync-connection-link').click(function (event) {
     data: {
       installationId: $(event.target).data('installation-id'),
       jiraHost: $(event.target).data('jira-host'),
+      syncType: document.getElementById('sync-type').value,
       token: params.get('jwt'),
       _csrf: document.getElementById('_csrf').value
     },
@@ -66,3 +67,24 @@ $('.sync-connection-link').click(function (event) {
     }
   })
 })
+
+const modal = document.getElementById('sync-modal')
+
+const btn = document.getElementById('sync-modal-btn')
+
+const span = document.getElementsByClassName('close')[0]
+
+btn.onclick = function () {
+  modal.style.display = 'block'
+}
+
+span.onclick = function () {
+  modal.style.display = 'none'
+}
+
+// When the user clicks anywhere outside of the modal, close it
+window.onclick = function (event) {
+  if (event.target === modal) {
+    modal.style.display = 'none'
+  }
+}

--- a/static/js/jira-configuration.js
+++ b/static/js/jira-configuration.js
@@ -68,23 +68,35 @@ $('.sync-connection-link').click(function (event) {
   })
 })
 
-const modal = document.getElementById('sync-modal')
+const retryModal = document.getElementById('sync-retry-modal')
+const statusModal = document.getElementById('sync-status-modal')
+const retryBtn = document.getElementById('sync-retry-modal-btn')
+const statusBtn = document.getElementById('sync-status-modal-btn')
+const retrySpan = document.getElementById('retry-close')
+const statusSpan = document.getElementById('status-close')
 
-const btn = document.getElementById('sync-modal-btn')
-
-const span = document.getElementsByClassName('close')[0]
-
-btn.onclick = function () {
-  modal.style.display = 'block'
+retryBtn.onclick = function () {
+  retryModal.style.display = 'block'
 }
 
-span.onclick = function () {
-  modal.style.display = 'none'
+statusBtn.onclick = function () {
+  statusModal.style.display = 'block'
+}
+
+retrySpan.onclick = function () {
+  retryModal.style.display = 'none'
+}
+
+statusSpan.onclick = function () {
+  statusModal.style.display = 'none'
 }
 
 // When the user clicks anywhere outside of the modal, close it
 window.onclick = function (event) {
-  if (event.target === modal) {
-    modal.style.display = 'none'
+  if (event.target === retryModal) {
+    retryModal.style.display = 'none'
+  }
+  if (event.target === statusModal) {
+    statusModal.style.display = 'none'
   }
 }

--- a/test/unit/api/__snapshots__/api.test.js.snap
+++ b/test/unit/api/__snapshots__/api.test.js.snap
@@ -86,6 +86,8 @@ Object {
 }
 `;
 
+exports[`API Endpoints sync should reset repoSyncState if asked to 1`] = `"{\\"message\\":\\"Successfully (re)started sync for test-installation-id\\"}"`;
+
 exports[`API Endpoints sync should return 404 if no installation is found 1`] = `"Not Found"`;
 
 exports[`API Endpoints sync should trigger the sync or start function 1`] = `"{\\"message\\":\\"Successfully (re)started sync for test-installation-id\\"}"`;

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -34,7 +34,16 @@
                   <th>Added</th>
                   <th></th>
                   <th>Sync Status</th>
-                  <th>Retry</th>
+                  <th>Retry <span id="sync-modal-btn" class="sync-modal-btn">ℹ️</span></th>
+                  <div id="sync-modal" class="sync-modal">
+                    <div class="sync-modal-content">
+                      <span class="close">&times;</span>
+                      <p><strong>Normal</strong> - Retry if the sync failed and you haven't changed the configuration on GitHub.
+                      This will not attempt to rediscover the GitHub repositories in your installation.</p>
+                      <p><strong>Full</strong> - Rediscover your GitHub repositories and perform another full sync.
+                      Use this is you've changed the configuration on GitHub or would otherwise like to rescan all repositories.</p>
+                    </div>
+                  </div>
                 </tr>
               </thead>
               <tbody>
@@ -58,7 +67,11 @@
                     </td>
                     <td>
                       <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
-                      <button class="ak-button ak-button__appearance-link sync-connection-link" data-jira-host="{{ ../host }}" data-installation-id="{{ id }}">🔄</button>
+                      <select id="sync-type">
+                        <option value="normal">Normal</option>
+                        <option value="full">Full</option>
+                      </select>
+                      <button class="ak-button ak-button__appearance-link sync-connection-link" data-jira-host="{{ ../host }}" data-installation-id="{{ id }}">Submit</button>
                     </td>
                   </tr>
                 {{/each}}

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -33,11 +33,21 @@
                   <th>Repositories</th>
                   <th>Added</th>
                   <th></th>
-                  <th>Sync Status</th>
-                  <th>Retry <span id="sync-modal-btn" class="sync-modal-btn">ℹ️</span></th>
-                  <div id="sync-modal" class="sync-modal">
-                    <div class="sync-modal-content">
-                      <span class="close">&times;</span>
+                  <th>Sync Status <span id="sync-status-modal-btn" class="sync-status-modal-btn">ℹ️</span></th></th>
+                  <div id="sync-status-modal" class="sync-retry-modal">
+                    <div class="sync-retry-modal-content">
+                      <span id="status-close" class="close">&times;</span>
+                      <p><strong>ACTIVE</strong> - The sync has started and is still in progress for this account. New data may not immediately be displayed in Jira.</p>
+                      <p><strong>FAILED</strong> - There was a problem syncing data from your account. If there were temporary technical issues, a normal resync will pick up from where it left off and continue with the sync.
+                      If it continues to return to FAILED state after re-trying, a full resync may be necessary.</p>
+                      <p><strong>PENDING</strong> - The sync has been queued, but is not actively syncing data from GitHub.</p>
+                      <p><strong>COMPLETE</strong> - The sync has finished. Information from selected repositories will be shown in Jira's development information panel.</p>
+                    </div>
+                  </div>
+                  <th>Retry <span id="sync-retry-modal-btn" class="sync-retry-modal-btn">ℹ️</span></th>
+                  <div id="sync-retry-modal" class="sync-retry-modal">
+                    <div class="sync-retry-modal-content">
+                      <span id="retry-close" class="close">&times;</span>
                       <p><strong>Normal</strong> - Retry if the sync failed and you haven't changed the configuration on GitHub.
                       This will not attempt to rediscover the GitHub repositories in your installation.</p>
                       <p><strong>Full</strong> - Rediscover your GitHub repositories and perform another full sync.


### PR DESCRIPTION
This adds an option through the UI and the staff API to allow a full resync. The way the sync works today, it will not rescan your entire installation if for example you add or removed repositories while the sync is in progress. This works fine if you add or remove a repository from the installation after the sync is complete, but a few users have realized they installed very large repositories and then removed them while the sync was in progress. This left the `repoSyncState` in a state where it is trying to sync repositories that it can no longer access. If this happens, the user needs a way to restart the sync from the beginning so we can clear out the state of any repositories that the sync can no longer access.

![image](https://user-images.githubusercontent.com/13207348/56174057-abaa4b00-5fbe-11e9-9cb5-0126ad0a1a16.png)

![image](https://user-images.githubusercontent.com/13207348/56174064-b1a02c00-5fbe-11e9-9df6-feb421e96587.png)

This also changes the API call to `repoSyncState` to require you to pass the `jiraHost` parameter. Before it was just finding the first subscription for a given github installation, but this is not always the subscription since you could have multiple jira instances wired up to one Org on GitHub.

cc @izuzak
