### PR TITLE
#189 - Update commandRegex to be more restrictive

### DIFF
--- a/lib/transforms/smart-commit.js
+++ b/lib/transforms/smart-commit.js
@@ -5,7 +5,7 @@
 
 const punct = '!"\\#$%&\'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~'
 const issueKeysRegex = new RegExp(`(?:(?<=[\\s${punct}])|^)([A-Z][A-Z\\d]+-\\d+)(?:(?=[\\s${punct}])|$)`, 'g')
-const commandRegex = /(?=#[A-Za-z-]+)/g
+const commandRegex = /(?=#[A-Za-z-]+(?:\s+|$))/g
 const timeRegex = /((?:(?:\d+[wdhm])\s*)+)\s*/
 
 function parseTime (text) {


### PR DESCRIPTION
A proper fix for #189 would be to check full command syntax but short term fix can be to just restrict the commandRegx to not match the general issues keys. 

New regex enforces either "end of string" or "one or more spaces" to be present after the  `#<COMMAND>` to ensure it does not match something like `[#ABC-123]` but match only `#ABC`