### PR TITLE
Update `CONTRIBUTING` steps to reflect current Jira Cloud UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,8 @@ For production you should just use `npm run start`.
 #### Configuring the Jira instance
 
 1. Create a new [free developer instance][jira-developer-instance] on Jira Cloud.
-2. From the left sidebar in Jira, select **Settings** -> **Add-ons** -> **Manage add-ons**. (If you're using an older version of Jira, you won't have a left sidebar. Instead, click the **Gear Icon** in the top-right corner and select **Settings**. From there, select **Manage add-ons** from the left sidebar.)
-3. Scroll down to beneath the User-installed add-ons table and select **Settings**.
+2. From the left sidebar in Jira, select **Settings** -> **Apps** -> **Manage apps**. (If you're using an older version of Jira, you won't have a left sidebar. Instead, click the **Gear Icon** in the top-right corner and select **Settings**. From there, select **Manage add-ons** from the left sidebar.)
+3. Verify the filter is set to `User-installed`, and select **Settings* beneath the User-installed add-ons table.
 4. On the Settings pop-up, add **Enable development mode** and click **Apply**.
 5. From the right header, select **Upload add-on** and enter `https://DOMAIN/jira/atlassian-connect.json`.
 6. Click **Upload**.


### PR DESCRIPTION
While going through the `CONTRIBUTING.md` file for [Configuring the Jira instace](https://github.com/integrations/jira/blob/master/CONTRIBUTING.md#configuring-the-jira-instance), I noticed there is a slight change of wording from `Add-ons` to `Apps`. Additionally the UI for enabling developer mode has changed very slightly.

This PR updates this wording. 👍 

/cc @tcbyrd I don't think this is anything that needs an immediate ship, but would be useful as others begin to look at contributing to the repo.