### PR TITLE
README.md: implement grammatical correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Read, Write, and Admin for Development Information (branches, commits, and pull 
 To access the development information in Jira...
 
 ### Take action using Smart Commits
-Smart commits are documented on the [Atlassian site](https://confluence.atlassian.com/fisheye/using-smart-commits-298976812.html) and allow to you comment on Jira issue in commit messages, branches, and pull requests. For example: `[JRA-123] fix typo` will be sent through to Jira and appear in the Development Information section of the Jira issue with the key `JRA-123`
+Smart commits are documented on the [Atlassian site](https://confluence.atlassian.com/fisheye/using-smart-commits-298976812.html) and allow you to comment on Jira issue in commit messages, branches, and pull requests. For example: `[JRA-123] fix typo` will be sent through to Jira and appear in the Development Information section of the Jira issue with the key `JRA-123`
 
 > example
 ![image](https://user-images.githubusercontent.com/13207348/46588447-61be3680-ca6a-11e8-9976-ba3d1d3c42bf.png)


### PR DESCRIPTION
This PR updates the README.md file implementing a grammatical correction in the documentation for Smart Commits:


```diff
- Smart commits are documented on the Atlassian site and allow **to you** comment on Jira issue in commit messages, branches, and pull requests. For example: `[JRA-123] fix typo` will be sent through to Jira and appear in the Development Information section of the Jira issue with the key `JRA-123`
+ Smart commits are documented on the Atlassian site and allow **you to** comment on Jira issue in commit messages, branches, and pull requests. For example: `[JRA-123] fix typo` will be sent through to Jira and appear in the Development Information section of the Jira issue with the key `JRA-123`
```