### PR TITLE
Sync more data from branches

### DIFF
--- a/lib/sync/commits.js
+++ b/lib/sync/commits.js
@@ -1,32 +1,48 @@
 const transformCommit = require('../transforms/commit')
-const { getCommits: getCommitsQuery } = require('./queries')
+const { getCommits: getCommitsQuery, getDefaultRef } = require('./queries')
 
 exports.getCommits = async (github, repository, cursor, perPage) => {
-  const commitsData = await github.query(getCommitsQuery, {
-    owner: repository.owner.login,
-    repo: repository.name,
-    per_page: perPage,
-    cursor
-  })
+  try {
+    const data = await github.query(getDefaultRef, {
+      owner: repository.owner.login,
+      repo: repository.name
+    })
 
-  // if the repository is empty, commitsData.repository.ref is null
-  const { edges } = commitsData.repository.ref
-    ? commitsData.repository.ref.target.history
-    : { edges: [] }
+    const refName = data.repository.defaultBranchRef.name
 
-  const authors = edges.map(({ node: item }) => item.author)
-  const commits = edges.map(({ node: item }) => {
-    // translating the object into a schema that matches our transforms
-    return {
-      author: item.author,
-      authorTimestamp: item.authoredDate,
-      fileCount: 0,
-      sha: item.oid,
-      message: item.message,
-      url: item.url
-    }
-  })
+    const commitsData = await github.query(getCommitsQuery, {
+      owner: repository.owner.login,
+      repo: repository.name,
+      per_page: perPage,
+      cursor,
+      default_ref: refName
+    })
 
-  const { data: jiraPayload } = transformCommit({ commits, repository }, authors)
-  return { edges, jiraPayload }
+    // if the repository is empty, commitsData.repository.ref is null
+    const { edges } = commitsData.repository.ref
+      ? commitsData.repository.ref.target.history
+      : { edges: [] }
+
+    const authors = edges.map(({ node: item }) => item.author)
+    const commits = edges.map(({ node: item }) => {
+      // translating the object into a schema that matches our transforms
+      return {
+        author: item.author,
+        authorTimestamp: item.authoredDate,
+        fileCount: 0,
+        sha: item.oid,
+        message: item.message,
+        url: item.url
+      }
+    })
+
+    const { data: jiraPayload } = transformCommit(
+      { commits, repository },
+      authors
+    )
+    return { edges, jiraPayload }
+  } catch (err) {
+    console.log(`Failed to get commit data for repository=${repository.name}`)
+    console.log(err)
+  }
 }

--- a/lib/sync/queries.js
+++ b/lib/sync/queries.js
@@ -35,9 +35,9 @@ module.exports = {
     }
   }`,
 
-  getCommits: `query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String) {
+  getCommits: `query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String, $default_ref: String!) {
     repository(owner: $owner, name: $repo){
-      ref(qualifiedName: "master") {
+      ref(qualifiedName: $default_ref) {
         target {
           ... on Commit {
             history(first: $per_page, after: $cursor) {
@@ -111,6 +111,13 @@ module.exports = {
         }
       }
     }
-  }
-  `
+  }`,
+
+  getDefaultRef: `query ($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo){
+        defaultBranchRef {
+          name
+        }
+    }      
+  }`
 }

--- a/lib/sync/queries.js
+++ b/lib/sync/queries.js
@@ -114,7 +114,7 @@ module.exports = {
   }`,
 
   getDefaultRef: `query ($owner: String!, $repo: String!) {
-    repository(owner: $owner, name: $repo){
+    repository(owner: $owner, name: $repo) {
         defaultBranchRef {
           name
         }

--- a/lib/sync/transforms/branch.js
+++ b/lib/sync/transforms/branch.js
@@ -1,25 +1,54 @@
 const parseSmartCommit = require('../../transforms/smart-commit')
 const { getJiraId } = require('../../jira/util/id')
 
+/**
+ * mapBranch takes a branch node from the GraphQL response and
+ * attempts to find issueKeys in use anywhere in that object
+ *
+ * Locations can include:
+ *  - Branch Name (ref)
+ *  - Title of the associated Pull Request
+ *  - Messages from up to the last 100 commits in that branch
+ * @param {Object} branch
+ * @param {Object} repository
+ */
 function mapBranch (branch, repository) {
-  const { issueKeys } = parseSmartCommit(branch.associatedPullRequestTitle)
+  // setup an empty array to hold any issues keys we can find
+  const allKeys = []
 
-  if (!issueKeys) {
+  const { issueKeys: branchKeys } = parseSmartCommit(branch.name)
+  const { issueKeys: pullRequestKeys } = parseSmartCommit(branch.associatedPullRequestTitle)
+  const { issueKeys: commitKeys } = parseSmartCommit(branch.lastCommit.message)
+
+  if (branchKeys) {
+    allKeys.push(branchKeys)
+  }
+
+  if (pullRequestKeys) {
+    allKeys.push(pullRequestKeys)
+  }
+
+  if (commitKeys) {
+    allKeys.push(commitKeys)
+  }
+
+  if (!allKeys) {
+    // If we get here, no issue keys were found anywhere they might be found
     return
   }
 
-  const { issueKeys: commitKeys } = parseSmartCommit(branch.lastCommit.message)
-  if (commitKeys) {
-    issueKeys.push(commitKeys.filter(Boolean))
-  }
-
-  const allKeys = issueKeys.filter(Boolean)
+  // If we do have some keys, let's flatten the array and filter outo any undefined values
+  const filteredKeys = allKeys.filter(Boolean)
     .reduce((a, b) => a.concat(b), [])
+
+  if (!filteredKeys.length) {
+    return
+  }
 
   return {
     createPullRequestUrl: `${repository.html_url}/pull/new/${branch.name}`,
     id: getJiraId(branch.name),
-    issueKeys: allKeys,
+    issueKeys: filteredKeys,
     lastCommit: {
       author: {
         avatar: branch.lastCommit.author.avatarUrl,
@@ -30,7 +59,7 @@ function mapBranch (branch, repository) {
       fileCount: branch.lastCommit.fileCount,
       hash: branch.lastCommit.sha,
       id: branch.lastCommit.sha,
-      issueKeys: allKeys,
+      issueKeys: filteredKeys,
       message: branch.lastCommit.message,
       url: branch.lastCommit.url,
       updateSequenceId: Date.now()
@@ -41,6 +70,12 @@ function mapBranch (branch, repository) {
   }
 }
 
+/**
+ * mapCommit takes the a single commit object from the array
+ * of commits we got from the GraphQL response and maps the data
+ * to the structure needed for the DevInfo API
+ * @param {Object} commit
+ */
 function mapCommit (commit) {
   const { issueKeys } = parseSmartCommit(commit.message)
 

--- a/lib/sync/transforms/branch.js
+++ b/lib/sync/transforms/branch.js
@@ -13,42 +13,25 @@ const { getJiraId } = require('../../jira/util/id')
  * @param {Object} repository
  */
 function mapBranch (branch, repository) {
-  // setup an empty array to hold any issues keys we can find
-  const allKeys = []
-
   const { issueKeys: branchKeys } = parseSmartCommit(branch.name)
   const { issueKeys: pullRequestKeys } = parseSmartCommit(branch.associatedPullRequestTitle)
   const { issueKeys: commitKeys } = parseSmartCommit(branch.lastCommit.message)
 
-  if (branchKeys) {
-    allKeys.push(branchKeys)
-  }
+  const allKeys = []
+    .concat(branchKeys)
+    .concat(pullRequestKeys)
+    .concat(commitKeys)
+    .filter(Boolean)
 
-  if (pullRequestKeys) {
-    allKeys.push(pullRequestKeys)
-  }
-
-  if (commitKeys) {
-    allKeys.push(commitKeys)
-  }
-
-  if (!allKeys) {
+  if (!allKeys.length) {
     // If we get here, no issue keys were found anywhere they might be found
-    return
-  }
-
-  // If we do have some keys, let's flatten the array and filter outo any undefined values
-  const filteredKeys = allKeys.filter(Boolean)
-    .reduce((a, b) => a.concat(b), [])
-
-  if (!filteredKeys.length) {
     return
   }
 
   return {
     createPullRequestUrl: `${repository.html_url}/pull/new/${branch.name}`,
     id: getJiraId(branch.name),
-    issueKeys: filteredKeys,
+    issueKeys: allKeys,
     lastCommit: {
       author: {
         avatar: branch.lastCommit.author.avatarUrl,
@@ -59,7 +42,8 @@ function mapBranch (branch, repository) {
       fileCount: branch.lastCommit.fileCount,
       hash: branch.lastCommit.sha,
       id: branch.lastCommit.sha,
-      issueKeys: filteredKeys,
+      // Use only one set of keys for the last commit in order of most specific to least specific
+      issueKeys: commitKeys || branchKeys || pullRequestKeys,
       message: branch.lastCommit.message,
       url: branch.lastCommit.url,
       updateSequenceId: Date.now()
@@ -111,7 +95,7 @@ module.exports = (payload) => {
     return branch.commits.map(commit => mapCommit(commit)).filter(Boolean)
   })
 
-  if (!commits) {
+  if (!commits.length && !branches.length) {
     return {}
   }
 

--- a/lib/sync/transforms/branch.js
+++ b/lib/sync/transforms/branch.js
@@ -95,7 +95,7 @@ module.exports = (payload) => {
     return branch.commits.map(commit => mapCommit(commit)).filter(Boolean)
   })
 
-  if (!commits.length && !branches.length) {
+  if ((!commits || !commits.length) && (!branches || !branches.length)) {
     return {}
   }
 

--- a/test/fixtures/api/graphql/branch-associated-pr-has-keys.json
+++ b/test/fixtures/api/graphql/branch-associated-pr-has-keys.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "edges": [
+          {
+            "cursor": "MQ",
+            "node": {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "title": "PULL-123 Test Pull Request"
+                  }
+                ]
+              },
+              "name": "dev",
+              "target": {
+                "author": {
+                  "avatarUrl": "https://camo.githubusercontent.com/test-avatar",
+                  "email": "test-author-email@example.com",
+                  "name": "test-author-name"
+                },
+                "authoredDate": "test-authored-date",
+                "history": {
+                  "nodes": [
+                    {
+                      "message": "test-commit-message",
+                      "oid": "test-oid",
+                      "authoredDate": "test-authored-date",
+                      "author": {
+                        "avatarUrl": "https://camo.githubusercontent.com/test-avatar",
+                        "email": "test-author-email@example.com",
+                        "name": "test-author-name",
+                        "user": null
+                      },
+                      "url": "test-repo-url/commit/test-sha"
+                    }
+                  ]
+                },
+                "oid": "test-oid",
+                "message": "test-commit-message",
+                "url": "test-repo-url/commit/test-sha"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/api/graphql/branch-commits-have-keys.json
+++ b/test/fixtures/api/graphql/branch-commits-have-keys.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "edges": [
+          {
+            "cursor": "MQ",
+            "node": {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "title": "Test Pull Request"
+                  }
+                ]
+              },
+              "name": "dev",
+              "target": {
+                "author": {
+                  "avatarUrl": "https://camo.githubusercontent.com/test-avatar",
+                  "email": "test-author-email@example.com",
+                  "name": "test-author-name"
+                },
+                "authoredDate": "test-authored-date",
+                "history": {
+                  "nodes": [
+                    {
+                      "message": "TES-123 test-commit-message",
+                      "oid": "test-oid",
+                      "authoredDate": "test-authored-date",
+                      "author": {
+                        "avatarUrl": "https://camo.githubusercontent.com/test-avatar",
+                        "email": "test-author-email@example.com",
+                        "name": "test-author-name",
+                        "user": null
+                      },
+                      "url": "test-repo-url/commit/test-sha"
+                    }
+                  ]
+                },
+                "oid": "test-oid",
+                "message": "TES-123 test-commit-message",
+                "url": "test-repo-url/commit/test-sha"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/api/graphql/branch-empty-nodes.json
+++ b/test/fixtures/api/graphql/branch-empty-nodes.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "edges": []
+      }
+    }
+  }
+}

--- a/test/fixtures/api/graphql/branch-no-issue-keys.json
+++ b/test/fixtures/api/graphql/branch-no-issue-keys.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "edges": [
+          {
+            "cursor": "MQ",
+            "node": {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "title": "Test Pull Request with no issue keys"
+                  }
+                ]
+              },
+              "name": "dev",
+              "target": {
+                "author": {
+                  "avatarUrl": "https://camo.githubusercontent.com/test-avatar",
+                  "email": "test-author-email@example.com",
+                  "name": "test-author-name"
+                },
+                "authoredDate": "test-authored-date",
+                "history": {
+                  "nodes": [
+                    {
+                      "message": "test-commit-message",
+                      "oid": "test-oid",
+                      "authoredDate": "test-authored-date",
+                      "author": {
+                        "avatarUrl": "https://camo.githubusercontent.com/test-avatar",
+                        "email": "test-author-email@example.com",
+                        "name": "test-author-name",
+                        "user": null
+                      },
+                      "url": "test-repo-url/commit/test-sha"
+                    }
+                  ]
+                },
+                "oid": "test-oid",
+                "message": "test-commit-message",
+                "url": "test-repo-url/commit/test-sha"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/api/graphql/branch-queries.js
+++ b/test/fixtures/api/graphql/branch-queries.js
@@ -1,0 +1,16 @@
+const query = 'query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String) {\n    repository(owner: $owner, name: $repo) {\n      refs(first: $per_page, refPrefix: "refs/heads/", after: $cursor) {\n        edges {\n          cursor\n          node {\n            associatedPullRequests(first:1) {\n              nodes {\n                title\n              }\n            }\n            name\n            target {\n              ... on Commit {\n                author {\n                  avatarUrl\n                  email\n                  name\n                }\n                authoredDate\n                history(first: $per_page) {\n                  nodes {\n                    message\n                    oid\n                    authoredDate\n                    author {\n                      avatarUrl\n                      email\n                      name\n                      user {\n                        url\n                      }\n                    }\n                    url\n                  }\n                }\n                oid\n                message\n                url\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n  '
+
+module.exports.branchesNoLastCursor = {
+  query,
+  variables: { owner: 'integrations', repo: 'test-repo-name', per_page: 50 }
+}
+
+module.exports.branchesWithLastCursor = {
+  query,
+  variables: {
+    owner: 'integrations',
+    repo: 'test-repo-name',
+    per_page: 50,
+    cursor: 'MQ'
+  }
+}

--- a/test/fixtures/api/graphql/branch-ref-nodes.json
+++ b/test/fixtures/api/graphql/branch-ref-nodes.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "edges": [
+          {
+            "cursor": "MQ",
+            "node": {
+              "associatedPullRequests": {
+                "nodes": [
+                  {
+                    "title": "Test Pull Request"
+                  }
+                ]
+              },
+              "name": "TES-321-branch-name",
+              "target": {
+                "author": {
+                  "avatarUrl": "https://camo.githubusercontent.com/test-avatar",
+                  "email": "test-author-email@example.com",
+                  "name": "test-author-name"
+                },
+                "authoredDate": "test-authored-date",
+                "history": {
+                  "nodes": [
+                    {
+                      "message": "TES-123 test-commit-message",
+                      "oid": "test-oid",
+                      "authoredDate": "test-authored-date",
+                      "author": {
+                        "avatarUrl": "https://camo.githubusercontent.com/test-avatar",
+                        "email": "test-author-email@example.com",
+                        "name": "test-author-name",
+                        "user": null
+                      },
+                      "url": "test-repo-url/commit/test-sha"
+                    }
+                  ]
+                },
+                "oid": "test-oid",
+                "message": "TES-123 test-commit-message",
+                "url": "test-repo-url/commit/test-sha"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/api/graphql/commit-queries.js
+++ b/test/fixtures/api/graphql/commit-queries.js
@@ -1,8 +1,8 @@
-const query = 'query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String) {\n    repository(owner: $owner, name: $repo){\n      ref(qualifiedName: "master") {\n        target {\n          ... on Commit {\n            history(first: $per_page, after: $cursor) {\n              edges {\n                cursor\n                node {\n                  author {\n                    avatarUrl\n                    email\n                    name\n                    user {\n                      url\n                    }\n                  }\n                  authoredDate\n                  message\n                  oid\n                  url\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n  '
+const query = 'query ($owner: String!, $repo: String!, $per_page: Int!, $cursor: String, $default_ref: String!) {\n    repository(owner: $owner, name: $repo){\n      ref(qualifiedName: $default_ref) {\n        target {\n          ... on Commit {\n            history(first: $per_page, after: $cursor) {\n              edges {\n                cursor\n                node {\n                  author {\n                    avatarUrl\n                    email\n                    name\n                    user {\n                      url\n                    }\n                  }\n                  authoredDate\n                  message\n                  oid\n                  url\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n  '
 
 module.exports.commitsNoLastCursor = {
   query,
-  variables: { owner: 'integrations', repo: 'test-repo-name', per_page: 50 }
+  variables: { owner: 'integrations', repo: 'test-repo-name', per_page: 50, default_ref: 'master' }
 }
 
 module.exports.commitsWithLastCursor = {
@@ -11,6 +11,17 @@ module.exports.commitsWithLastCursor = {
     owner: 'integrations',
     repo: 'test-repo-name',
     per_page: 50,
-    cursor: 'Y3Vyc29yOnYyOpK5MjAxsdlkwOC0yM1QxNzozODowNS0wNDowMM4MjT7J 99'
+    cursor: 'Y3Vyc29yOnYyOpK5MjAxsdlkwOC0yM1QxNzozODowNS0wNDowMM4MjT7J 99',
+    default_ref: 'master'
+  }
+}
+
+const defaultBranchQuery = 'query ($owner: String!, $repo: String!) {\n    repository(owner: $owner, name: $repo) {\n        defaultBranchRef {\n          name\n        }\n    }      \n  }'
+
+module.exports.getDefaultBranch = {
+  query: defaultBranchQuery,
+  variables: {
+    owner: 'integrations',
+    repo: 'test-repo-name'
   }
 }

--- a/test/fixtures/api/graphql/default-branch.json
+++ b/test/fixtures/api/graphql/default-branch.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "repository": {
+      "defaultBranchRef": {
+        "name": "master"
+      }
+    }
+  }
+}

--- a/test/unit/sync/branch.test.js
+++ b/test/unit/sync/branch.test.js
@@ -1,0 +1,239 @@
+const nock = require('nock')
+const parseSmartCommit = require('../../../lib/transforms/smart-commit')
+const emptyNodesFixture = require('../../fixtures/api/graphql/branch-empty-nodes.json')
+
+function makeExpectedResponse ({branchName}) {
+  const { issueKeys } = parseSmartCommit(branchName)
+  return {
+    preventTransitions: false,
+    repositories: [
+      {
+        branches: [
+          {
+            createPullRequestUrl: 'test-repo-url/pull/new/' + branchName,
+            id: branchName,
+            issueKeys: ['TES-123'].concat(issueKeys).reverse().filter(Boolean),
+            lastCommit: {
+              author: {
+                avatar: 'https://camo.githubusercontent.com/test-avatar',
+                name: 'test-author-name'
+              },
+              authorTimestamp: 'test-authored-date',
+              displayId: 'test-o',
+              fileCount: 0,
+              hash: 'test-oid',
+              id: 'test-oid',
+              issueKeys: ['TES-123'].concat(issueKeys).reverse().filter(Boolean),
+              message: 'TES-123 test-commit-message',
+              url: 'test-repo-url/commit/test-sha',
+              updateSequenceId: 12345678
+            },
+            name: branchName,
+            url: 'test-repo-url/tree/' + branchName,
+            updateSequenceId: 12345678
+          }
+        ],
+        commits: [
+          {
+            author: {
+              avatar: 'https://camo.githubusercontent.com/test-avatar',
+              email: 'test-author-email@example.com',
+              name: 'test-author-name'
+            },
+            authorTimestamp: 'test-authored-date',
+            displayId: 'test-o',
+            fileCount: 0,
+            hash: 'test-oid',
+            id: 'test-oid',
+            issueKeys: ['TES-123'],
+            message: 'TES-123 test-commit-message',
+            timestamp: 'test-authored-date',
+            url: 'test-repo-url/commit/test-sha',
+            updateSequenceId: 12345678
+          }
+        ],
+        id: 'test-repo-id',
+        name: 'test-repo-name',
+        url: 'test-repo-url',
+        updateSequenceId: 12345678
+      }
+    ],
+    properties: {
+      installationId: 'test-installation-id'
+    }
+  }
+}
+
+function nockBranchRequst (payload) {
+  nock('https://api.github.com')
+    .post('/installations/1/access_tokens')
+    .reply(200, { token: '1234' })
+
+  const { branchesNoLastCursor, branchesWithLastCursor } = require('../../fixtures/api/graphql/commit-queries')
+  nock('https://api.github.com')
+    .post('/graphql', branchesNoLastCursor)
+    .reply(200, payload)
+  nock('https://api.github.com')
+    .post('/graphql', branchesWithLastCursor)
+    .reply(200, emptyNodesFixture)
+}
+
+describe('sync/branches', () => {
+  let jiraHost
+  let jiraApi
+  let installationId
+  let delay
+  let attempts = 3
+
+  beforeEach(() => {
+    const models = td.replace('../../../lib/models')
+    const repoSyncStatus = {
+      installationId: 12345678,
+      jiraHost: 'tcbyrd.atlassian.net',
+      repos: {
+        'test-repo-id': {
+          repository: {
+            name: 'test-repo-name',
+            owner: { login: 'integrations' },
+            html_url: 'test-repo-url',
+            id: 'test-repo-id'
+          },
+          pullStatus: 'complete',
+          branchStatus: 'pending',
+          commitStatus: 'complete'
+        }
+      }
+    }
+    delay = process.env.LIMITER_PER_INSTALLATION = 2000
+
+    jiraHost = process.env.ATLASSIAN_URL
+    jiraApi = td.api('https://test-atlassian-instance.net')
+
+    installationId = 'test-installation-id'
+    Date.now = jest.fn(() => 12345678)
+
+    td.when(
+      models.Subscription.getSingleInstallation(jiraHost, installationId)
+    ).thenReturn({
+      jiraHost,
+      id: 1,
+      get: () => repoSyncStatus,
+      set: () => repoSyncStatus,
+      save: () => Promise.resolve({}),
+      update: () => Promise.resolve({})
+    })
+  })
+
+  test('should sync to Jira when branch refs have jira references', async () => {
+    const { processInstallation } = require('../../../lib/sync/installation')
+
+    const job = {
+      data: { installationId, jiraHost },
+      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
+    }
+
+    nock('https://api.github.com')
+      .post('/installations/1/access_tokens')
+      .reply(200, { token: '1234' })
+
+    const branchNodesFixture = require('../../fixtures/api/graphql/branch-ref-nodes.json')
+    nockBranchRequst(branchNodesFixture)
+
+    const queues = {
+      installation: {
+        add: jest.fn()
+      }
+    }
+    await processInstallation(app, queues)(job)
+    expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts)
+
+    td.verify(
+      jiraApi.post('/rest/devinfo/0.10/bulk', makeExpectedResponse({ branchName: 'TES-321-branch-name' }))
+    )
+  })
+
+  test('should send data if issue keys are only present in commits', async () => {
+    const { processInstallation } = require('../../../lib/sync/installation')
+
+    const job = {
+      data: { installationId, jiraHost },
+      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
+    }
+
+    const branchCommitsHaveKeys = require('../../fixtures/api/graphql/branch-commits-have-keys.json')
+    nockBranchRequst(branchCommitsHaveKeys)
+
+    const queues = {
+      installation: {
+        add: jest.fn()
+      }
+    }
+    await processInstallation(app, queues)(job)
+    expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts)
+
+    td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', makeExpectedResponse({
+      branchName: 'dev'
+    })))
+  })
+
+  test('should send data if issue keys are only present in an associatd PR title', async () => {
+    const { processInstallation } = require('../../../lib/sync/installation')
+
+    const job = {
+      data: { installationId, jiraHost },
+      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
+    }
+
+    const associatedPRhasKeys = require('../../fixtures/api/graphql/branch-associated-PR-has-keys.json')
+    nockBranchRequst(associatedPRhasKeys)
+
+    const queues = {
+      installation: {
+        add: jest.fn()
+      }
+    }
+    await processInstallation(app, queues)(job)
+    expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts)
+
+    td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
+      preventTransitions: false,
+      repositories: [
+        {
+          branches: [
+            {
+              createPullRequestUrl: 'test-repo-url/pull/new/dev',
+              id: 'dev',
+              issueKeys: ['PULL-123'],
+              lastCommit: {
+                author: {
+                  avatar: 'https://camo.githubusercontent.com/test-avatar',
+                  name: 'test-author-name'
+                },
+                authorTimestamp: 'test-authored-date',
+                displayId: 'test-o',
+                fileCount: 0,
+                hash: 'test-oid',
+                issueKeys: ['PULL-123'],
+                id: 'test-oid',
+                message: 'test-commit-message',
+                url: 'test-repo-url/commit/test-sha',
+                updateSequenceId: 12345678
+              },
+              name: 'dev',
+              url: 'test-repo-url/tree/dev',
+              updateSequenceId: 12345678
+            }
+          ],
+          commits: [],
+          id: 'test-repo-id',
+          name: 'test-repo-name',
+          url: 'test-repo-url',
+          updateSequenceId: 12345678
+        }
+      ],
+      properties: {
+        installationId: 'test-installation-id'
+      }
+    }))
+  })
+})

--- a/test/unit/sync/branch.test.js
+++ b/test/unit/sync/branch.test.js
@@ -184,7 +184,7 @@ describe('sync/branches', () => {
       opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
     }
 
-    const associatedPRhasKeys = require('../../fixtures/api/graphql/branch-associated-PR-has-keys.json')
+    const associatedPRhasKeys = require('../../fixtures/api/graphql/branch-associated-pr-has-keys.json')
     nockBranchRequst(associatedPRhasKeys)
 
     const queues = {

--- a/test/unit/sync/commits.test.js
+++ b/test/unit/sync/commits.test.js
@@ -1,4 +1,5 @@
 const nock = require('nock')
+const defaultBranchFixture = require('../../fixtures/api/graphql/default-branch.json')
 
 describe('sync/commits', () => {
   let jiraHost
@@ -59,7 +60,10 @@ describe('sync/commits', () => {
 
     const commitNodesFixture = require('../../fixtures/api/graphql/commit-nodes.json')
 
-    const { commitsNoLastCursor, commitsWithLastCursor } = require('../../fixtures/api/graphql/commit-queries')
+    const { commitsNoLastCursor, commitsWithLastCursor, getDefaultBranch } = require('../../fixtures/api/graphql/commit-queries')
+
+    nock('https://api.github.com').post('/graphql', getDefaultBranch)
+      .reply(200, defaultBranchFixture)
     nock('https://api.github.com').post('/graphql', commitsNoLastCursor)
       .reply(200, commitNodesFixture)
     nock('https://api.github.com').post('/graphql', commitsWithLastCursor)
@@ -118,7 +122,10 @@ describe('sync/commits', () => {
 
     const mixedCommitNodes = require('../../fixtures/api/graphql/commit-nodes-mixed.json')
 
-    const { commitsNoLastCursor, commitsWithLastCursor } = require('../../fixtures/api/graphql/commit-queries')
+    const { commitsNoLastCursor, commitsWithLastCursor, getDefaultBranch } = require('../../fixtures/api/graphql/commit-queries')
+
+    nock('https://api.github.com').post('/graphql', getDefaultBranch)
+      .reply(200, defaultBranchFixture)
     nock('https://api.github.com').post('/graphql', commitsNoLastCursor)
       .reply(200, mixedCommitNodes)
     nock('https://api.github.com').post('/graphql', commitsWithLastCursor)
@@ -211,7 +218,10 @@ describe('sync/commits', () => {
 
     const commitsNoKeys = require('../../fixtures/api/graphql/commit-nodes-no-keys.json')
 
-    const { commitsNoLastCursor, commitsWithLastCursor } = require('../../fixtures/api/graphql/commit-queries')
+    const { commitsNoLastCursor, commitsWithLastCursor, getDefaultBranch } = require('../../fixtures/api/graphql/commit-queries')
+
+    nock('https://api.github.com').post('/graphql', getDefaultBranch)
+      .reply(200, defaultBranchFixture)
     nock('https://api.github.com').post('/graphql', commitsNoLastCursor)
       .reply(200, commitsNoKeys)
     nock('https://api.github.com').post('/graphql', commitsWithLastCursor)
@@ -239,7 +249,10 @@ describe('sync/commits', () => {
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
-    const { commitsNoLastCursor, commitsWithLastCursor } = require('../../fixtures/api/graphql/commit-queries')
+    const { commitsNoLastCursor, commitsWithLastCursor, getDefaultBranch } = require('../../fixtures/api/graphql/commit-queries')
+
+    nock('https://api.github.com').post('/graphql', getDefaultBranch)
+      .reply(200, defaultBranchFixture)
     nock('https://api.github.com').post('/graphql', commitsNoLastCursor)
       .reply(200, emptyNodesFixture)
     nock('https://api.github.com').post('/graphql', commitsWithLastCursor)


### PR DESCRIPTION
It looks like there's a lot going on in this PR, but a lot of it is just beefing up our tests to make sure we're catching edge cases like this. The core of what I'm proposing here is in the `mapBranch` function:

https://github.com/integrations/jira/blob/5dd752f5dd270887bb084b70ab0c7438333c211e/lib/sync/transforms/branch.js#L4-L39

The goal of this PR is to map more data to the DevInfo API in Jira during the initial sync. Currently, if the branch doesn't have an issue key in it, we stop processing that branch. What users expect is for any commit with an issue key to also make that branch show up in the DevInfo panel. This is how it works for new data, but during the initial sync we were filtering out branches if the name of the branch didn't look like it needed to sync.

The function above does this by looking at the data we get back from the `getBranches` query, which includes the branch name and the latest 50 commits for that branch. If it finds issue keys anywhere in that branch, it will now sync the branch and PR to Jira. Additionally, if the PR has an issue key in the title, the branch for that PR will also be included.

I'm also adding one little fix that's been bothering me: 

https://github.com/integrations/jira/blob/5dd752f5dd270887bb084b70ab0c7438333c211e/lib/sync/commits.js#L6-L19

This will ensure a full historical commit sync is done from the `default ref`, which __may or may not__ be called `master`. This way if someone is using a default branch called something like `dev`, it will sync everything from that branch instead of `master`.