### PR TITLE
Update Smart Commits link to point to JIRA doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Read, Write, and Admin for Development Information (branches, commits, and pull 
 To access the development information in Jira...
 
 ### Take action using Smart Commits
-Smart commits are documented on the [Atlassian site](https://confluence.atlassian.com/fisheye/using-smart-commits-298976812.html) and allow you to comment on Jira issue in commit messages, branches, and pull requests. For example: `[JRA-123] fix typo` will be sent through to Jira and appear in the Development Information section of the Jira issue with the key `JRA-123`
+Smart Commits are documented on the [Atlassian site](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) and allow you to comment on Jira issue in commit messages, branches, and pull requests. For example: `[JRA-123] fix typo` will be sent through to Jira and appear in the Development Information section of the Jira issue with the key `JRA-123`
 
 > example
 ![image](https://user-images.githubusercontent.com/13207348/46588447-61be3680-ca6a-11e8-9976-ba3d1d3c42bf.png)


### PR DESCRIPTION
The previous link pointed at the Fish Eye article, which included some irrelevant information and omitted a few valuable bits.

Fixes #207