### PR TITLE
Update newrelic to latest minor release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,17 +56,17 @@
       }
     },
     "@newrelic/koa": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.6.tgz",
-      "integrity": "sha512-V7TR4fMeSjmM6XyT2YDebQ/wQzmVDq+g7Mn3fQItvGWOR+y3kzPoQS7w0hCU6+imPsr3N+GC6Xcj+4EWTHxT3w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.8.tgz",
+      "integrity": "sha512-kY//FlLQkGdUIKEeGJlyY3dJRU63EG77YIa48ACMGZxQbWRd3WZMikyft33f8XScTq6WpCDo9xa0viNo8zeYkg==",
       "requires": {
         "methods": "^1.1.2"
       }
     },
     "@newrelic/native-metrics": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-3.1.1.tgz",
-      "integrity": "sha512-ndKpzty0IGPMBbDFOR/ny/Q9/ccxDZqi1xjGP9SKp5aS4dfcZ/yfl6GUuXIjKePRBmLprKxXELynf5u9RxIwNQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-3.1.2.tgz",
+      "integrity": "sha512-JjUmPrp2LEEkhVtelICme5p7sHHpfpu2Wjk5/L1D3Zvt01v4mCsrL2XaIMBmHgg3T2ZbqMiqWZCn2LtGZ6nklA==",
       "optional": true,
       "requires": {
         "nan": "^2.10.0",
@@ -74,11 +74,19 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-          "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "optional": true
         }
+      }
+    },
+    "@newrelic/superagent": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-1.0.3.tgz",
+      "integrity": "sha512-lJbsqKa79qPLbHZsbiRaXl1jfzaXAN7zqqnLRqBY+zI/O5zcfyNngTmdi+9y+qIUq7xHYNaLsAxCXerrsoINKg==",
+      "requires": {
+        "methods": "^1.1.2"
       }
     },
     "@octokit/rest": {
@@ -228,9 +236,9 @@
       "integrity": "sha512-/gwCgiI2e9RzzZTKbl+am3vgNqOt7a9fJ/uxv4SqYKxenoEDNVU3KZEadlpusWhQI0A0dOrZ0T68JYKVjzmgdQ=="
     },
     "@tyriar/fibonacci-heap": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.8.tgz",
-      "integrity": "sha512-yujW2S09dkH3uBUiTR5GtMni7LgQS2bSm1ezjugyUzuzM7JUkNvNRMwUL7/bee8gv812zhw1Yw/aIzL47UbTVQ=="
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
+      "integrity": "sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA=="
     },
     "abab": {
       "version": "2.0.0",
@@ -6542,12 +6550,13 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "newrelic": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-4.8.1.tgz",
-      "integrity": "sha512-IKOpXM3BRxUrzxcsBagJsMOIYJr/VsScubHXMRTAesFM7ljdGcBE2arEXy/crgiZWyl0GKKmbVZLsO3M9ZsByg==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-4.13.1.tgz",
+      "integrity": "sha512-M2o/9vsekKedBfiYtvs1MV5hDBuuqInNYd979luvNoqUZzuCjtNHQ8GPn3b5vDwr4YkmPQD9gfhuX6/id/iuXQ==",
       "requires": {
         "@newrelic/koa": "^1.0.0",
         "@newrelic/native-metrics": "^3.0.0",
+        "@newrelic/superagent": "^1.0.0",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "async": "^2.1.4",
         "concat-stream": "^1.5.0",
@@ -6558,12 +6567,17 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
           "requires": {
-            "lodash": "^4.17.10"
+            "lodash": "^4.17.14"
           }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "express-sslify": "^1.2.0",
     "helmet": "^3.13.0",
     "markdown": "^0.5.0",
-    "newrelic": "^4.8.1",
+    "newrelic": "^4.13.1",
     "pg": "^7.4.3",
     "primer": "^10.6.0",
     "probot": "^7.1.2",


### PR DESCRIPTION
After shipping #222 it looks like a number of errors are related to trying to send data to NewRelic. This bumps to latest newrelic dependency in an attempt to quiet those alerts.