### PR TITLE
Add indexes for subscriptions transactions

### DIFF
--- a/db/migrations/20190807230019-add-indexes.js
+++ b/db/migrations/20190807230019-add-indexes.js
@@ -4,7 +4,7 @@ module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.addIndex('Subscriptions', {
       fields: ['gitHubInstallationId', 'jiraHost'],
-      name: 'index-on-installation-and-jira-host'
+      name: 'Subscriptions_gitHubInstallationId_jiraHost_idx'
     })
 
     await queryInterface.addIndex('Subscriptions', {

--- a/db/migrations/20190807230019-add-indexes.js
+++ b/db/migrations/20190807230019-add-indexes.js
@@ -4,17 +4,23 @@ module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.addIndex('Subscriptions', {
       fields: ['gitHubInstallationId', 'jiraHost'],
-      name: 'index-on-installation-and-jirahost'
+      name: 'index-on-installation-and-jira-host'
     })
 
     await queryInterface.addIndex('Subscriptions', {
-      fields: ['gitHubInstallationId'],
-      name: 'index-on-github-installation-id'
+      fields: ['jiraHost'],
+      name: 'index-on-jira-host'
+    })
+
+    await queryInterface.addIndex('Subscriptions', {
+      fields: ['jiraClientKey'],
+      name: 'index-on-jira-client-key'
     })
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.removeIndex('Subscriptions', 'index-on-installation-and-jirahost')
-    await queryInterface.removeIndex('Subscriptions', 'index-on-github-installation-id')
+    await queryInterface.removeIndex('Subscriptions', 'index-on-installation-and-jira-host')
+    await queryInterface.removeIndex('Subscriptions', 'index-on-jira-host')
+    await queryInterface.removeIndex('Subscriptions', 'index-on-jira-client-key')
   }
 }

--- a/db/migrations/20190807230019-add-indexes.js
+++ b/db/migrations/20190807230019-add-indexes.js
@@ -9,18 +9,18 @@ module.exports = {
 
     await queryInterface.addIndex('Subscriptions', {
       fields: ['jiraHost'],
-      name: 'index-on-jira-host'
+      name: 'Subscriptions_jiraHost_idx'
     })
 
     await queryInterface.addIndex('Subscriptions', {
       fields: ['jiraClientKey'],
-      name: 'index-on-jira-client-key'
+      name: 'Subscriptions_jiraClientKey_idx'
     })
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.removeIndex('Subscriptions', 'index-on-installation-and-jira-host')
-    await queryInterface.removeIndex('Subscriptions', 'index-on-jira-host')
-    await queryInterface.removeIndex('Subscriptions', 'index-on-jira-client-key')
+    await queryInterface.removeIndex('Subscriptions', 'Subscriptions_gitHubInstallationId_jiraHost_idx')
+    await queryInterface.removeIndex('Subscriptions', 'Subscriptions_jiraHost_idx')
+    await queryInterface.removeIndex('Subscriptions', 'Subscriptions_jiraClientKey_idx')
   }
 }

--- a/db/migrations/20190807230019-add-indexes.js
+++ b/db/migrations/20190807230019-add-indexes.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('Subscriptions', {
+      fields: ['gitHubInstallationId', 'jiraHost'],
+      name: 'index-on-installation-and-jirahost'
+    })
+
+    await queryInterface.addIndex('Subscriptions', {
+      fields: ['gitHubInstallationId'],
+      name: 'index-on-github-installation-id'
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('Subscriptions', 'index-on-installation-and-jirahost')
+    await queryInterface.removeIndex('Subscriptions', 'index-on-github-installation-id')
+  }
+}


### PR DESCRIPTION
This adds two indexes for the Subscriptions table. One for `githubInstallationId` and `jiraHost`, and another for just `gitHubInstallationId`.