### PR TITLE
Ignore .DS_Store and logs/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ npm-debug.log
 *.pem
 .env
 coverage
-.vscode
+.vscodelog/*
+.DS_Store
+log/*


### PR DESCRIPTION
`.DS_Store` files are created by Finder in macOS and aren't useful when committed. I've started to pipe output to `logs/*` for reference later and so I'm ignoring it as well.