### PR TITLE
Add index on Projects

### DIFF
--- a/db/migrations/20190807234327-add-indexes-on-projects.js
+++ b/db/migrations/20190807234327-add-indexes-on-projects.js
@@ -1,0 +1,12 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('Projects', {
+      fields: ['jiraHost', 'projectKey'],
+      name: 'Projects_jiraHost_projectKey_idx'
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('Projects', 'Projects_jiraHost_projectKey_idx')
+  }
+}


### PR DESCRIPTION
**tl;dr** Execution time dropped from 85ms to ~0.1ms.

This index should dramatically improve a query that takes 21% of the total database time.

```
 total_exec_time | prop_exec_time |  ncalls   |  sync_io_time   |                                                                                                                                         query
-----------------+----------------+-----------+-----------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 03:39:55.74488  | 52.7%          | 2,710,622 | 00:00:00.085608 | SELECT "id", "gitHubInstallationId", "jiraHost", "selectedRepositories", "repoSyncState", "syncStatus", "jiraClientKey", "createdAt", "updatedAt" FROM "Subscriptions" AS "Subscription" WHERE "Subscription"."gitHubInstallationId" = $1
 01:28:22.313629 | 21.2%          | 715,672   | 00:00:00.000512 | SELECT "id", "projectKey", "occurrences", "jiraHost", "createdAt", "updatedAt" FROM "Projects" AS "Project" WHERE "Project"."projectKey" = $1 AND "Project"."jiraHost" = $2 LIMIT $3
```

It is our second most expensive query. (The first is improved by #225.)

## Query plan, before and after

I tested this locally against a million rows.

```
jira-dev=# SELECT COUNT(*) FROM "Projects";
  count  
---------
 1048576
(1 row)
```

**Before**

```
jira-dev=# EXPLAIN ANALYZE SELECT "id", "projectKey", "occurrences", "jiraHost", "createdAt", "updatedAt" FROM "Projects" AS "Project" WHERE "Project"."projectKey" = 'WS' AND "Project"."jiraHost" = 'https://jnraine.atlassian.net' LIMIT 1;
                                                                QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1000.00..17353.70 rows=1 width=44) (actual time=0.202..85.029 rows=1 loops=1)
   ->  Gather  (cost=1000.00..17353.70 rows=1 width=44) (actual time=0.201..85.027 rows=1 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Parallel Seq Scan on "Projects" "Project"  (cost=0.00..16353.60 rows=1 width=44) (actual time=50.421..50.421 rows=0 loops=3)
               Filter: ((("projectKey")::text = 'WS'::text) AND (("jiraHost")::text = 'https://jnraine.atlassian.net'::text))
               Rows Removed by Filter: 349498
 Planning Time: 0.074 ms
 Execution Time: 85.049 ms
(9 rows)
```

**After**

```
jira-dev=# EXPLAIN ANALYZE SELECT "id", "projectKey", "occurrences", "jiraHost", "createdAt", "updatedAt" FROM "Projects" AS "Project" WHERE "Project"."projectKey" = 'WS' AND "Project"."jiraHost" = 'https://jnraine.atlassian.net' LIMIT 1;
                                                                           QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.42..8.45 rows=1 width=44) (actual time=0.060..0.085 rows=1 loops=1)
   ->  Index Scan using "Projects_jiraHost_projectKey_idx" on "Projects" "Project"  (cost=0.42..8.45 rows=1 width=44) (actual time=0.059..0.061 rows=1 loops=1)
         Index Cond: ((("jiraHost")::text = 'https://jnraine.atlassian.net'::text) AND (("projectKey")::text = 'WS'::text))
 Planning Time: 0.334 ms
 Execution Time: 0.114 ms
(5 rows)
```

The execution time dropped from 85ms to ~0.1ms. Woohoo! :tada: