### PR TITLE
Improve installation verification

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -4,6 +4,9 @@ const app = express()
 const bodyParser = require('body-parser').urlencoded({ extended: false })
 const octokit = require('@octokit/rest')()
 
+const { Installation } = require('../models')
+const verifyInstallation = require('../jira/verify-installation')
+
 async function getInstallation (client, subscription) {
   const id = subscription.gitHubInstallationId
   try {
@@ -180,6 +183,32 @@ app.post('/:installationId/sync', bodyParser, async (req, res) => {
   } catch (err) {
     console.log(err)
     return res.sendStatus(401)
+  }
+})
+
+app.post('/jira/:installationId/verify', bodyParser, async (req, response) => {
+  const { installationId } = req.params
+  const installation = await Installation.findById(installationId)
+
+  const respondWith = function (message) {
+    const data = {
+      message: message,
+      installation: { enabled: installation.enabled, id: installation.id, jiraHost: installation.jiraHost }
+    }
+
+    return response.send(JSON.stringify(data))
+  }
+
+  if (installation.enabled) {
+    respondWith('Installation already enabled')
+  } else {
+    await verifyInstallation(installation, req.log)()
+
+    if (installation.enabled) {
+      respondWith('Verification successful')
+    } else {
+      respondWith('Verification failed')
+    }
   }
 })
 

--- a/lib/jira/enable.js
+++ b/lib/jira/enable.js
@@ -1,33 +1,15 @@
 const Installation = require('../models/installation')
-const getAxiosInstance = require('../jira/client/axios')
+const verifyInstallation = require('./verify-installation')
 
 module.exports = async (req, res) => {
-  const installation = await Installation.getPendingHost(req.body.baseUrl)
+  const jiraHost = req.body.baseUrl
+
+  const installation = await Installation.getPendingHost(jiraHost)
   if (installation) {
+    res.on('finish', verifyInstallation(installation, req.log))
     res.sendStatus(204)
-    res.on('finish', async () => {
-      const instance = getAxiosInstance(null, {}, installation.jiraHost, installation.sharedSecret)
-      try {
-        // Validate the clientKey and the sharedSecret
-        // We have to do this after responding with 204 because
-        // otherwise we get an error "The add-on is not enabled"
-        // no matter what we send
-        const result = await instance.get(`/rest/devinfo/0.10/existsByProperties?fakeProperty=1`)
-        if (result.status === 200) {
-          req.log('App enabled on Jira')
-          await installation.enable()
-        } else {
-          req.log('App not installed. Verification failed.')
-        }
-      } catch (err) {
-        if (err.response.status === 401) {
-          req.log('Jira does not recognize this installation. Deleting it.')
-          await Installation.uninstall({ clientKey: req.body.clientKey })
-        }
-      }
-    })
   } else {
-    req.log(`No pending installation found for ${req.body.baseUrl}`)
+    req.log(`No pending installation found for jiraHost=${jiraHost}`)
     res.sendStatus(422)
   }
 }

--- a/lib/jira/verify-installation.js
+++ b/lib/jira/verify-installation.js
@@ -1,0 +1,28 @@
+const getAxiosInstance = require('../jira/client/axios')
+const { Sentry } = require('../error-handler')
+
+module.exports = function (installation, log) {
+  return async () => {
+    const instance = getAxiosInstance(null, {}, installation.jiraHost, installation.sharedSecret)
+
+    try {
+      const result = await instance.get(`/rest/devinfo/0.10/existsByProperties?fakeProperty=1`)
+      if (result.status === 200) {
+        log('App enabled on Jira')
+        installation.enable()
+      } else {
+        const message = `Unable to verify Jira installation: ${installation.jiraHost} responded with ${result.status}`
+        log(message)
+        Sentry.captureMessage(message)
+      }
+    } catch (err) {
+      if (err.response && err.response.status === 401) {
+        log('Jira does not recognize this installation. Deleting it.')
+        installation.destroy()
+      } else {
+        log(`Unhandled error during verification: ${err}`)
+        Sentry.captureException(err)
+      }
+    }
+  }
+}

--- a/lib/models/installation.js
+++ b/lib/models/installation.js
@@ -50,10 +50,10 @@ module.exports = class Installation extends Sequelize.Model {
     })
   }
 
-  static async getPendingHost (host) {
+  static async getPendingHost (jiraHost) {
     return Installation.findOne({
       where: {
-        jiraHost: host,
+        jiraHost,
         enabled: false
       }
     })


### PR DESCRIPTION
This aims to fix [`Cannot destructure property jiraHost of 'undefined' or 'null'.`](https://sentry.io/organizations/github-integrations/issues/1143967447)

The [installation flow](https://developer.atlassian.com/cloud/jira/platform/authentication-for-apps/) for an [Jira Cloud app](https://developer.atlassian.com/cloud/jira/platform/integrating-with-jira-cloud/) (like this codebase) has two steps:

1. **Install**. Atlassian makes an unauthenticated request to us, providing a shared secret. We store the secret in the database. The secret can't be used until step two.
2. **Enable**. Atlassian makes an authenticated request using the shared secret. We then make an authenticated request to their API. If we are successful, we mark the installation as enabled.

We have more than [30 installations](https://data.heroku.com/dataclips/xrrkxmxsgsgzgpujqbkbrstlbrjf) that have repository subscriptions but aren't enabled. We don't know for certain what causes this. My current hypothesis is that a race condition causes our verification in step two to never happen.

We send the request status _before_ adding the `finish` callback:

https://github.com/integrations/jira/blob/c903c49eed1a7bfce5e5e2ffece71158b1736f22/lib/jira/enable.js#L7-L8

## Solution

1. **Fix the (potential) bug.** This removes the possible race condition by adding the callback before sending a response.

2. **Add endpoint to fix bad installations.** This adds `POST /api/jira/<id>/verify`, accessible to GitHub staff only, to trigger verification for a given Jira installation ID. This should allow us to fix installations that are still valid and clean up those that aren't.