### PR TITLE
Add script/server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_URL=
 WEBHOOK_SECRET=development
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+TUNNEL_PORT=4002
+TUNNEL_SUBDOMAIN=<yourname>-jira
 
 # Use `trace` to get verbose logging or `info` to show less
 LOG_LEVEL=debug

--- a/Brewfile
+++ b/Brewfile
@@ -1,2 +1,3 @@
 brew "node"
 brew "postgresql"
+brew "overmind"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Finally, set the `APP_URL` env variable to `https://DOMAIN`.
 When you are developing you will prefer to run the app and automatically restart it when you do changes to the source code. In that case you should use:
 
 ```
-$ npm run dev
+$ script/server
 ```
 
 For production you should just use `npm run start`.

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+tunnel: script/tunnel
+web: nodemon --exec "npm start"
+worker: nodemon --exec "npm run worker"

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 tunnel: script/tunnel
-web: nodemon --exec "npm start"
-worker: nodemon --exec "npm run worker"
+web: npm run dev
+worker: npm run dev:worker

--- a/lib/jira/disable.js
+++ b/lib/jira/disable.js
@@ -1,8 +1,8 @@
 module.exports = async (req, res) => {
-  req.log('App disabled on Jira.')
-
   const { installation } = res.locals
   await installation.disable()
+
+  req.log(`Installation id=${installation.id} disabled on Jira`)
 
   return res.sendStatus(204)
 }

--- a/lib/jira/uninstall.js
+++ b/lib/jira/uninstall.js
@@ -1,8 +1,6 @@
 const { Installation, Subscription } = require('../models')
 
 module.exports = async (req, res) => {
-  req.log('App uninstalled on Jira. Removing secrets.')
-
   const { installation } = res.locals
   const subscriptions = await Subscription.getAllForHost(installation.jiraHost)
 
@@ -11,6 +9,8 @@ module.exports = async (req, res) => {
       return subscription.uninstall()
     }))
   }
+
+  req.log(`App uninstalled on Jira. Uninstalling id=${installation.id}.`)
 
   await Installation.uninstall({
     clientKey: req.body.clientKey

--- a/lib/jira/verify-installation.js
+++ b/lib/jira/verify-installation.js
@@ -8,7 +8,7 @@ module.exports = function (installation, log) {
     try {
       const result = await instance.get(`/rest/devinfo/0.10/existsByProperties?fakeProperty=1`)
       if (result.status === 200) {
-        log('App enabled on Jira')
+        log(`Installation id=${installation.id} enabled on Jira`)
         installation.enable()
       } else {
         const message = `Unable to verify Jira installation: ${installation.jiraHost} responded with ${result.status}`
@@ -17,10 +17,10 @@ module.exports = function (installation, log) {
       }
     } catch (err) {
       if (err.response && err.response.status === 401) {
-        log('Jira does not recognize this installation. Deleting it.')
+        log(`Jira does not recognize installation id=${installation.id}. Deleting it`)
         installation.destroy()
       } else {
-        log(`Unhandled error during verification: ${err}`)
+        log(`Unhandled error while verifying installation id=${installation.id}: ${err}`)
         Sentry.captureException(err)
       }
     }

--- a/lib/run.js
+++ b/lib/run.js
@@ -15,7 +15,7 @@ const probot = createProbot({
   id: process.env.APP_ID,
   secret: process.env.WEBHOOK_SECRET,
   cert: findPrivateKey(),
-  port: process.env.PORT || 3000,
+  port: process.env.TUNNEL_PORT || process.env.PORT || 3000,
   webhookPath: '/github/events',
   webhookProxy: process.env.WEBHOOK_PROXY_URL
 })

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "ci": "npm test && npm run lint",
     "dev": "nodemon --exec \"npm start\"",
+    "dev:worker": "nodemon --exec \"node bin/worker\"",
     "lint": "standard --fix",
     "es": "eslint",
     "start": "node ./lib/run.js",

--- a/script/server
+++ b/script/server
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DIR=$(dirname "${BASH_SOURCE[0]}")/
+source "${DIR}/utils.sh"
+
+if is_installed overmind; then
+  exec overmind start --procfile="Procfile.dev"
+else
+  echo_red "Overmind not found!"
+  echo "To install, run this:"
+  echo_bold "  brew install overmind"
+fi

--- a/script/tunnel
+++ b/script/tunnel
@@ -14,9 +14,9 @@ elif [ -z ${TUNNEL_SUBDOMAIN} ]; then
   exit 1
 fi
 
-if is_installed ngrok1; then
+if is_installed ngrok; then
   exec ngrok http "${TUNNEL_PORT}" --subdomain="${TUNNEL_SUBDOMAIN}" --log=stdout
-elif is_installed lt1; then
+elif is_installed lt; then
   exec lt --port "${TUNNEL_PORT}" --subdomain "${TUNNEL_SUBDOMAIN}" --print-requests
 else
   echo_red "No tunnel utility found!"

--- a/script/tunnel
+++ b/script/tunnel
@@ -1,0 +1,27 @@
+#!/bin/bash
+# 
+# Start tunnel for server using ngrok or localtunnel
+# 
+
+DIR=$(dirname "${BASH_SOURCE[0]}")/
+source "${DIR}/utils.sh"
+
+if [ -z ${TUNNEL_PORT} ]; then
+  echo "TUNNEL_PORT must be set"
+  exit 1
+elif [ -z ${TUNNEL_SUBDOMAIN} ]; then
+  echo "TUNNEL_SUBDOMAIN must be set"
+  exit 1
+fi
+
+if is_installed ngrok1; then
+  exec ngrok http "${TUNNEL_PORT}" --subdomain="${TUNNEL_SUBDOMAIN}" --log=stdout
+elif is_installed lt1; then
+  exec lt --port "${TUNNEL_PORT}" --subdomain "${TUNNEL_SUBDOMAIN}" --print-requests
+else
+  echo_red "No tunnel utility found!"
+  echo "To install, run this:"
+  echo_bold "  brew install ngrok # requires license"
+  echo "            or"
+  echo_bold "  brew install localtunnel # free"
+fi

--- a/script/tunnel
+++ b/script/tunnel
@@ -21,7 +21,7 @@ elif is_installed lt; then
 else
   echo_red "No tunnel utility found!"
   echo "To install, run this:"
-  echo_bold "  brew install ngrok # requires license"
+  echo_bold "  brew cask install ngrok # requires license"
   echo "            or"
-  echo_bold "  brew install localtunnel # free"
+  echo_bold "  npm install -g localtunnel # free"
 fi

--- a/script/utils.sh
+++ b/script/utils.sh
@@ -1,0 +1,11 @@
+is_installed () {
+  which $@ >/dev/null
+}
+
+echo_red () {
+  echo -e "\033[1;31m${@}\033[0m"
+}
+
+echo_bold () {
+  echo -e "\033[3;34m${@}\033[0m"
+}


### PR DESCRIPTION
Mirroring the monolith, you can now start the app with a single command:

```
script/server
```

![script-server](https://user-images.githubusercontent.com/300976/62806233-1f5cf000-baa7-11e9-9f65-2366947af6f8.gif)

This sets up a tunnel using ngrok or localtunnel, starts a web server, and starts a worker. Both the web and worker will restart upon file changes.

In order to handle the tunnel, I’ve added `TUNNEL_PORT` and `TUNNEL_SUBDOMAIN` to `.env.example`. Once set, these values will be used to open a tunnel using a consistent subdomain.

While ngrok provides the best experience, I have included support for localtunnel because it is free. Even if you can’t buy an ngrok license, you can setup the app locally.