### PR TITLE
Add installation ID to log message

### DIFF
--- a/lib/jira/disable.js
+++ b/lib/jira/disable.js
@@ -1,8 +1,8 @@
 module.exports = async (req, res) => {
-  req.log('App disabled on Jira.')
-
   const { installation } = res.locals
   await installation.disable()
+
+  req.log(`Installation id=${installation.id} disabled on Jira`)
 
   return res.sendStatus(204)
 }

--- a/lib/jira/uninstall.js
+++ b/lib/jira/uninstall.js
@@ -1,8 +1,6 @@
 const { Installation, Subscription } = require('../models')
 
 module.exports = async (req, res) => {
-  req.log('App uninstalled on Jira. Removing secrets.')
-
   const { installation } = res.locals
   const subscriptions = await Subscription.getAllForHost(installation.jiraHost)
 
@@ -11,6 +9,8 @@ module.exports = async (req, res) => {
       return subscription.uninstall()
     }))
   }
+
+  req.log(`App uninstalled on Jira. Uninstalling id=${installation.id}.`)
 
   await Installation.uninstall({
     clientKey: req.body.clientKey

--- a/lib/jira/verify-installation.js
+++ b/lib/jira/verify-installation.js
@@ -8,7 +8,7 @@ module.exports = function (installation, log) {
     try {
       const result = await instance.get(`/rest/devinfo/0.10/existsByProperties?fakeProperty=1`)
       if (result.status === 200) {
-        log('App enabled on Jira')
+        log(`Installation id=${installation.id} enabled on Jira`)
         installation.enable()
       } else {
         const message = `Unable to verify Jira installation: ${installation.jiraHost} responded with ${result.status}`
@@ -17,10 +17,10 @@ module.exports = function (installation, log) {
       }
     } catch (err) {
       if (err.response && err.response.status === 401) {
-        log('Jira does not recognize this installation. Deleting it.')
+        log(`Jira does not recognize installation id=${installation.id}. Deleting it`)
         installation.destroy()
       } else {
-        log(`Unhandled error during verification: ${err}`)
+        log(`Unhandled error while verifying installation id=${installation.id}: ${err}`)
         Sentry.captureException(err)
       }
     }


### PR DESCRIPTION
We received an uninstall request from Jira and it appears to have disabled an installation that was still working.

Unfortunately, we can’t be certain of this because the logs don’t include the installation ID. This updates `uninstall.js` to ensure that, should we see this again, we will have confirmation of the problem. As a precautionary measure, I’ve also added installation ID to other log messages.