### PR TITLE
Set Sentry environment to NODE_ENV

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -4,9 +4,8 @@ const Integrations = require('@sentry/integrations')
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  release: process.env.HEROKU_SLUG_COMMIT
-    ? process.env.HEROKU_SLUG_COMMIT
-    : undefined,
+  environment: process.env.NODE_ENV,
+  release: process.env.HEROKU_SLUG_COMMIT,
   integrations: [
     new Integrations.Transaction(),
     new Integrations.Debug(),


### PR DESCRIPTION
This will allow us to send production and staging to a single project on Sentry.