### PR TITLE
Allow Sentry environment to be set

### DIFF
--- a/bin/worker
+++ b/bin/worker
@@ -9,7 +9,7 @@ const Sentry = require('@sentry/node')
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV,
+  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
   release: process.env.HEROKU_SLUG_COMMIT
 })
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -9,7 +9,7 @@ const Sentry = require('@sentry/node')
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV,
+  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
   release: process.env.HEROKU_SLUG_COMMIT
 })
 


### PR DESCRIPTION
If set, `SENTRY_ENV` will be used as the environment when errors are sent to Sentry over `NODE_ENV`. This change is necessary because `NODE_ENV=production` in our staging environment. This is to make it as production-like as possible. However, in this one way, we want staging to be different.

Prior to this, we got aroudn this by using separate Sentry projects for production and staging. This worked but required developers to know about and look at two projects. Sentry has good support for multiple environments per project and so this change aligns us better with how Sentry is designed to be used.