### PR TITLE
Add STALLED sync status

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -36,6 +36,8 @@ You can check your sync status in the integration settings:
 | PENDING  | The sync has not started.  |
 | ACTIVE   | The sync has started and is still in progress. No information will be displayed in Jira. |
 | COMPLETE | The sync has finished. Information will be displayed in Jira. |
+| STALLED  | The sync has not finished but has stopped being updated. Partial information may appear in Jira. |
+| FAILED   | The sync hit an error and stopped without completing. Partial information may appear in Jira. |
 
 The time it takes to complete the sync will depend on the size of your installation. Since the sync scans commits for every repository in your installation, be mindful that selecting "All Repositories" will perform a scan of every repository in your account, including forks. If you have repositories with hundreds of thousands of forks (e.g. a fork of the Linux repo), the scan might take several hours to complete.
 
@@ -51,6 +53,17 @@ Because everyone's repository histories are different, it's difficult to determi
 This will rediscover all repositories in your installation and start a new sync.
 
 Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
+
+## Sync is STALLED
+
+When an ACTIVE sync hasn't made progress for some time, the status will move to STALLED. This can happen when an unexpected error occurs.
+
+To resolve, follow these steps to resume the sync:
+
+1. Open the integration settings: **Jira Settings** -> **Add-ons** -> **Manage Add-ons** -> **GitHub** -> **Get started**
+2. Under **Retry**, click the dropdown and select "Normal", then click **Submit**
+
+If the sync returns to the STALLED status, [contact GitHub Support for additional help](#getting-additional-help).
 
 ## Nothing showing up in Jira
 

--- a/lib/frontend/get-jira-configuration.js
+++ b/lib/frontend/get-jira-configuration.js
@@ -1,4 +1,5 @@
 const format = require('date-fns/format')
+const moment = require('moment')
 const { Subscription } = require('../models')
 
 async function getInstallation (client, subscription) {
@@ -6,9 +7,17 @@ async function getInstallation (client, subscription) {
   try {
     const response = await client.apps.getInstallation({ installation_id: id })
     response.data.syncStatus = subscription.isActiveSyncStalled() ? 'STALLED' : subscription.syncStatus
+    response.data.subscriptionUpdatedAt = formatDate(subscription.updatedAt)
     return response.data
   } catch (err) {
     return { error: err, id, deleted: err.code === 404 }
+  }
+}
+
+const formatDate = function (date) {
+  return {
+    relative: moment(date).fromNow(),
+    absolute: format(date, 'MMMM D, YYYY h:mm a')
   }
 }
 
@@ -23,7 +32,7 @@ module.exports = async (req, res) => {
     .map(data => ({
       ...data,
       isGlobalInstall: data.repository_selection === 'all',
-      updated_at: format(data.updated_at, 'MMMM D, YYYY h:mm a'),
+      installedAt: formatDate(data.updated_at),
       syncState: data.syncState
     }))
   const failedConnections = installations.filter(response => response.error)

--- a/lib/frontend/get-jira-configuration.js
+++ b/lib/frontend/get-jira-configuration.js
@@ -5,7 +5,7 @@ async function getInstallation (client, subscription) {
   const id = subscription.gitHubInstallationId
   try {
     const response = await client.apps.getInstallation({ installation_id: id })
-    response.data.syncStatus = subscription.syncStatus
+    response.data.syncStatus = subscription.isActiveSyncStalled() ? 'STALLED' : subscription.syncStatus
     return response.data
   } catch (err) {
     return { error: err, id, deleted: err.code === 404 }

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -110,4 +110,16 @@ module.exports = class Subscription extends Sequelize.Model {
   async uninstall () {
     return this.destroy()
   }
+
+  // A stalled active sync is one that is ACTIVE but has not seen any updates in the last 15 minutes
+  // This may happen when an error causes a sync to die without setting the status to 'FAILED'
+  isActiveSyncStalled () {
+    if (this.syncStatus === 'ACTIVE') {
+      const fifteenMinutesAgo = new Date(new Date() - (15 * 60 * 1000))
+
+      return this.updatedAt < fifteenMinutesAgo
+    } else {
+      return false
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6613,9 +6613,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
       "version": "0.5.17",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express-sslify": "^1.2.0",
     "helmet": "^3.13.0",
     "markdown": "^0.5.0",
+    "moment": "^2.24.0",
     "moo": "^0.5.0",
     "newrelic": "^4.13.1",
     "pg": "^7.4.3",

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -46,6 +46,7 @@
                       <p><strong>COMPLETE</strong> - The sync has finished. Information from selected repositories will be shown in Jira's development information panel.</p>
                     </div>
                   </div>
+                  <th>Last Update</th>
                   <th>Retry <span id="sync-retry-modal-btn" class="sync-retry-modal-btn">ℹ️</span></th>
                   <div id="sync-retry-modal" class="sync-retry-modal">
                     <div class="sync-retry-modal-content">
@@ -69,13 +70,22 @@
                         Selected
                       {{/if}}
                     </td>
-                    <td>{{ updated_at }}</td>
+                    <td>
+                      <span title="{{ installedAt.absolute }}">
+                        {{ installedAt.relative }}
+                      </span>
+                    </td>
                     <td>
                       <button class="ak-button ak-button__appearance-link delete-connection-link" data-installation-id="{{ id }}">Remove</button>
                       <a class="ak-button ak-button__appearance-link configure-connection-link" href="{{ html_url }}" data-installation-link="{{ html_url }}" target="_blank">Configure</a>
                     </td>
                     <td>
                       <span id="{{id}}-status"> {{ syncStatus }} </span>
+                    </td>
+                    <td>
+                      <span title="{{ subscriptionUpdatedAt.absolute }}">
+                        {{ subscriptionUpdatedAt.relative }}
+                      </span>
                     </td>
                     <td>
                       <input type="hidden" id="_csrf" name="_csrf" value="{{../csrfToken}}">
@@ -97,8 +107,11 @@
                         There was an error getting the information of this installation
                       {{/if}}
                     </td>
-                    <td></td>
-                    <td>{{ updated_at }}</td>
+                    <td>
+                      <span title="{{ installedAt.absolute }}">
+                        {{ installedAt.relative }}
+                      </span>
+                    </td>
                     <td>
                       <button class="ak-button ak-button__appearance-link delete-connection-link" data-installation-id="{{ id }}">Remove</button>
                     </td>

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -38,6 +38,8 @@
                     <div class="sync-retry-modal-content">
                       <span id="status-close" class="close">&times;</span>
                       <p><strong>ACTIVE</strong> - The sync has started and is still in progress for this account. New data may not immediately be displayed in Jira.</p>
+                      <p><strong>STALLED</strong> - The sync has not made any progress for at least 15 minutes. If there were temporary technical issues, a normal resync will pick up from where it left off and continue with the
+                      sync.</p>
                       <p><strong>FAILED</strong> - There was a problem syncing data from your account. If there were temporary technical issues, a normal resync will pick up from where it left off and continue with the sync.
                       If it continues to return to FAILED state after re-trying, a full resync may be necessary.</p>
                       <p><strong>PENDING</strong> - The sync has been queued, but is not actively syncing data from GitHub.</p>

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -46,7 +46,7 @@
                       <p><strong>COMPLETE</strong> - The sync has finished. Information from selected repositories will be shown in Jira's development information panel.</p>
                     </div>
                   </div>
-                  <th>Last Update</th>
+                  <th>Last Sync Update</th>
                   <th>Retry <span id="sync-retry-modal-btn" class="sync-retry-modal-btn">ℹ️</span></th>
                   <div id="sync-retry-modal" class="sync-retry-modal">
                     <div class="sync-retry-modal-content">


### PR DESCRIPTION
When an active sync has not been updated in the last fifteen minutes, assume something went wrong and mark it as staled. We make a best effort to mark syncs that have failed due to an error as “FAILED” but there are cases where the error handler doesn’t run.

![image](https://user-images.githubusercontent.com/300976/63135501-ffd03680-bf82-11e9-9ea2-33da69022c8d.png)

While we work to resolve these issues, the customer shouldn’t need to wait 48 hours before knowing something isn’t working as it should. This helps avoid that.