### PR TITLE
Throw more specific exceptions

### DIFF
--- a/lib/frontend/get-github-configuration.js
+++ b/lib/frontend/get-github-configuration.js
@@ -3,7 +3,7 @@ const { Installation } = require('../models')
 
 module.exports = async (req, res, next) => {
   if (!req.session.githubToken || !req.session.jiraHost) {
-    return next(new Error('Unauthorized'))
+    return next(new Error('GitHub token or jiraHost missing'))
   }
 
   const { github, client, isAdmin } = res.locals
@@ -46,7 +46,7 @@ module.exports = async (req, res, next) => {
       // If we get here, there was either a problem decoding the JWT
       // or getting the data we need from GitHub, so we'll show the user an error.
       console.log(err)
-      return next(new Error('Unauthorized'))
+      return next(err)
     }
   } else {
     return res.redirect(


### PR DESCRIPTION
This is a small tweak to improve the exceptions sent to Sentry.

The first case gives a better idea to the investigating developer. The second case ensures the original exception is sent on to Sentry, including any specifics returned by the GitHub API.

These are minor changes but every bit helps.