### PR TITLE
Add additional context to exceptions during jobs

### DIFF
--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -1,5 +1,3 @@
-const Sentry = require('@sentry/node')
-
 const { Subscription } = require('../models')
 const getJiraClient = require('../jira/client')
 const { getRepositorySummary } = require('./jobs')
@@ -80,9 +78,7 @@ module.exports.processInstallation = (app, queues) => {
   return async function (job) {
     const { installationId, jiraHost } = job.data
 
-    Sentry.setExtra('jobData', job.data)
-    Sentry.setTag('jiraHost', jiraHost)
-    Sentry.setUser({ gitHubInstallationId: installationId, jiraHost })
+    job.sentry.setUser({ gitHubInstallationId: installationId, jiraHost })
 
     app.log(`Starting job for installationId=${installationId}`)
 
@@ -134,16 +130,20 @@ module.exports.processInstallation = (app, queues) => {
           await jiraClient.devinfo.repository.update(jiraPayload)
         } catch (err) {
           if (err.response && err.response.status === 400) {
-            Sentry.setExtra('Response body', err.response.data.errorMessages)
-            Sentry.setExtra('Jira payload', err.response.data.jiraPayload)
+            job.sentry.setExtra('Response body', err.response.data.errorMessages)
+            job.sentry.setExtra('Jira payload', err.response.data.jiraPayload)
           }
 
           if (err.request) {
-            Sentry.setExtra('Request', { host: err.request.domain, path: err.request.path, method: err.request.method })
+            job.sentry.setExtra('Request', { host: err.request.domain, path: err.request.path, method: err.request.method })
           }
 
           if (err.response) {
-            Sentry.setExtra('Response', { status: err.response.status, statusText: err.response.statusText })
+            job.sentry.setExtra('Response', {
+              status: err.response.status,
+              statusText: err.response.statusText,
+              body: err.response.body
+            })
           }
 
           throw new Error(`Failed Jira API request: ${err.response.status}`)

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -42,22 +42,42 @@ Object.keys(queues).forEach(name => {
   queue.on('failed', async (job, err) => {
     app.log.error(`Error occurred while processing job id=${job.id} on queue name=${name}`)
 
-    Sentry.setTag('queue', name)
-    Sentry.setExtra('jobData', Object.assign(job.data, { id: job.id }))
-    Sentry.captureException(err)
-
     const subscription = await Subscription.getSingleInstallation(job.data.jiraHost, job.data.installationId)
     await subscription.update({ syncStatus: 'FAILED' })
   })
 })
 
+// Return an async function that assigns a Sentry hub to `job.sentry` and sends exceptions.
+const sentryMiddleware = function (jobHandler) {
+  return async (job) => {
+    job.sentry = new Sentry.Hub(Sentry.getCurrentHub().getClient())
+
+    try {
+      await jobHandler(job)
+    } catch (err) {
+      job.sentry.setExtra('job', {
+        id: job.id,
+        attemptsMade: job.attemptsMade,
+        timestamp: new Date(job.timestamp),
+        data: job.data
+      })
+
+      job.sentry.setTag('jiraHost', job.data.jiraHost)
+      job.sentry.setTag('queue', job.queue.name)
+      job.sentry.captureException(err)
+
+      throw err
+    }
+  }
+}
+
 module.exports = {
   queues,
 
   start () {
-    queues.discovery.process(5, discovery(app, queues))
-    queues.installation.process(Number(CONCURRENT_WORKERS), processInstallation(app, queues))
-    queues.push.process(Number(CONCURRENT_WORKERS), limiterPerInstallation(processPush(app)))
+    queues.discovery.process(5, sentryMiddleware(discovery(app, queues)))
+    queues.installation.process(Number(CONCURRENT_WORKERS), sentryMiddleware(processInstallation(app, queues)))
+    queues.push.process(Number(CONCURRENT_WORKERS), sentryMiddleware(limiterPerInstallation(processPush(app))))
     app.log(`Worker process started with ${CONCURRENT_WORKERS} CONCURRENT WORKERS`)
   },
 

--- a/test/setup/create-job.js
+++ b/test/setup/create-job.js
@@ -1,0 +1,16 @@
+// Create a job stub with data
+const createJob = ({ data, opts }) => {
+  const defaultOpts = {
+    attempts: 3,
+    removeOnFail: true,
+    removeOnComplete: true
+  }
+
+  return {
+    data: data,
+    opts: Object.assign(defaultOpts, opts || {}),
+    sentry: { setUser: () => { } }
+  }
+}
+
+module.exports = createJob

--- a/test/unit/sync/branch.test.js
+++ b/test/unit/sync/branch.test.js
@@ -84,7 +84,6 @@ describe('sync/branches', () => {
   let jiraApi
   let installationId
   let delay
-  let attempts = 3
 
   beforeEach(() => {
     const models = td.replace('../../../lib/models')

--- a/test/unit/sync/branch.test.js
+++ b/test/unit/sync/branch.test.js
@@ -1,6 +1,7 @@
 const nock = require('nock')
 const parseSmartCommit = require('../../../lib/transforms/smart-commit')
 const emptyNodesFixture = require('../../fixtures/api/graphql/branch-empty-nodes.json')
+const createJob = require('../../setup/create-job')
 
 function makeExpectedResponse ({branchName}) {
   const { issueKeys } = parseSmartCommit(branchName)
@@ -127,10 +128,7 @@ describe('sync/branches', () => {
   test('should sync to Jira when branch refs have jira references', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com')
       .post('/installations/1/access_tokens')
@@ -155,10 +153,7 @@ describe('sync/branches', () => {
   test('should send data if issue keys are only present in commits', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     const branchCommitsHaveKeys = require('../../fixtures/api/graphql/branch-commits-have-keys.json')
     nockBranchRequst(branchCommitsHaveKeys)
@@ -179,10 +174,7 @@ describe('sync/branches', () => {
   test('should send data if issue keys are only present in an associatd PR title', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     const associatedPRhasKeys = require('../../fixtures/api/graphql/branch-associated-pr-has-keys.json')
     nockBranchRequst(associatedPRhasKeys)
@@ -240,10 +232,7 @@ describe('sync/branches', () => {
   test('should not call Jira if no issue keys are found', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     const branchNoIssueKeys = require('../../fixtures/api/graphql/branch-no-issue-keys.json')
     nockBranchRequst(branchNoIssueKeys)

--- a/test/unit/sync/commits.test.js
+++ b/test/unit/sync/commits.test.js
@@ -1,5 +1,6 @@
 const nock = require('nock')
 const defaultBranchFixture = require('../../fixtures/api/graphql/default-branch.json')
+const createJob = require('../../setup/create-job')
 
 describe('sync/commits', () => {
   let jiraHost
@@ -7,7 +8,6 @@ describe('sync/commits', () => {
   let installationId
   let emptyNodesFixture
   let delay
-  let attempts = 3
 
   beforeEach(() => {
     const models = td.replace('../../../lib/models')
@@ -51,10 +51,7 @@ describe('sync/commits', () => {
   test('should sync to Jira when Commit Nodes have jira references', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -113,10 +110,7 @@ describe('sync/commits', () => {
   test('should send Jira all commits that have Issue Keys', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -209,10 +203,7 @@ describe('sync/commits', () => {
   test('should default to master branch if defaultBranchRef is null', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -272,10 +263,7 @@ describe('sync/commits', () => {
   test('should not call Jira if no issue keys are present', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -305,10 +293,7 @@ describe('sync/commits', () => {
   test('should not call Jira if no data is returned', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 

--- a/test/unit/sync/pull-requests.test.js
+++ b/test/unit/sync/pull-requests.test.js
@@ -1,4 +1,5 @@
 const nock = require('nock')
+const createJob = require('../../setup/create-job')
 
 describe('sync/pull-request', () => {
   let jiraHost
@@ -46,14 +47,8 @@ describe('sync/pull-request', () => {
   test('should sync to Jira when Pull Request Nodes have jira references', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: {
-        removeOnComplete: true,
-        removeOnFail: true,
-        attempts: 3
-      }
-    }
+    const job = createJob({ data: { installationId, jiraHost } })
+
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
     const { pullsNoLastCursor, pullsWithLastCursor } = require('../../fixtures/api/graphql/pull-queries')
@@ -114,14 +109,7 @@ describe('sync/pull-request', () => {
   test('should not sync if nodes are empty', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: {
-        removeOnComplete: true,
-        removeOnFail: true,
-        attempts: 3
-      }
-    }
+    const job = createJob({ data: { installationId, jiraHost } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -151,15 +139,7 @@ describe('sync/pull-request', () => {
   test('should not sync if nodes do not contain issue keys', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
     process.env.LIMITER_PER_INSTALLATION = 2000
-    const job = {
-      data: { installationId, jiraHost },
-      opts: {
-        removeOnComplete: true,
-        removeOnFail: true,
-        attempts: 3,
-        delay: 2000
-      }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay: 2000 } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 


### PR DESCRIPTION
Even though we see errors as they happen, we don't always have the context we need to diagnose and correct the issues. For example, we often don't know **what** was being done to trigger the error or **who** did it.

We have some information for the installation queue but nothing for pull requests. Further, because Sentry doesn't support Bull out-of-the-box, our existing strategy for capturing metadata may cause data to leak between jobs.

This improves on the existing code in a few ways:

1. Errors from all queues will now included job metadata, including job ID to tie it back the logs.
2. Errors from all queues will be searchable by `jiraHost` or `queue`.
3. Errors while updating Jira will included additional request and response data.
4. Error state will be isolated to each job.
5. Additional error metadata can be easily added by any job using `job.sentry.addExtra(...)`


[Click here](https://sentry.io/organizations/github-integrations/issues/1164659823/events/bb0928886e634d8784ccdd06be5ba547/?project=1240714&statsPeriod=14d) to see an error with the new metadata. 

Here's a look at the new tags:

![Screen Shot 2019-08-19 at 2 58 48 PM](https://user-images.githubusercontent.com/300976/63302557-37e0bd80-c292-11e9-9a30-6541f2cc4fcb.png)

## Details

This adds a middleware function that wraps job handlers with a Sentry hub. This is a variation on the example from [this issue](https://github.com/getsentry/sentry-javascript/issues/2171#issuecomment-516410622).

Now, jobs can access their own Sentry context using `job.sentry`:

```javascript
// Within the job
job.sentry.setExtra(“some info”, {foo: “bar”})
job.sentry.setTag(“jiraHost”, “whatever”)
```

I’ve added this middleware to all three queues so we should get information any job that has a problem, including the `queue`,`jiraHost`, and more.

---

1: We use multiple Express apps (Probot events, staff API, Jira configuration) and run background jobs using [Bull](https://optimalbits.github.io/bull/). Each needs to be monitored separately.