### PR TITLE
 Improve error handling for webhooks

### DIFF
--- a/lib/configure-robot.js
+++ b/lib/configure-robot.js
@@ -1,6 +1,3 @@
-const Sentry = require('@sentry/node')
-const sentryStream = require('bunyan-sentry-stream')
-
 const setupFrontend = require('./frontend')
 const setupGitHub = require('./github')
 const setupJira = require('./jira')
@@ -9,8 +6,6 @@ module.exports = (app) => {
   setupFrontend(app)
   setupGitHub(app)
   setupJira(app)
-
-  app.log.target.addStream(sentryStream(Sentry, 'error'))
 
   return app
 }

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -3,9 +3,25 @@ const getJiraClient = require('../jira/client')
 const getJiraUtil = require('../jira/util')
 const Sentry = require('@sentry/node')
 
-module.exports = function middleware (callback) {
+// Returns an async function that reports errors errors to Sentry.
+// This works similar to Sentry.withScope but works in an async context.
+// A new Sentry hub is assigned to context.sentry and can be used later to add context to the error message.
+const withSentry = function (callback) {
   return async (context) => {
-    Sentry.setExtra('GitHub Payload', {
+    context.sentry = new Sentry.Hub(Sentry.getCurrentHub().getClient())
+
+    try {
+      await callback(context)
+    } catch (err) {
+      context.sentry.captureException(err)
+      throw err
+    }
+  }
+}
+
+module.exports = function middleware (callback) {
+  return withSentry(async (context) => {
+    context.sentry.setExtra('GitHub Payload', {
       event: context.name,
       action: context.payload.action,
       id: context.id,
@@ -16,16 +32,25 @@ module.exports = function middleware (callback) {
       return
     }
 
-    const subscriptions = await Subscription.getAllForInstallation(context.payload.installation.id)
+    const gitHubInstallationId = context.payload.installation.id
+    const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId)
     if (!subscriptions.length) {
       return
     }
 
+    context.sentry.setTag('transaction', `webhook:${context.name}.${context.payload.action}`)
     for (let subscription of subscriptions) {
-      const jiraClient = await getJiraClient(context.id, context.payload.installation.id, subscription.jiraHost)
+      const jiraHost = subscription.jiraHost
+
+      context.sentry.setTag('jiraHost', jiraHost)
+      context.sentry.setTag('gitHubInstallationId', gitHubInstallationId)
+
+      context.sentry.setUser({ jiraHost, gitHubInstallationId })
+
+      const jiraClient = await getJiraClient(context.id, gitHubInstallationId, jiraHost)
       const util = getJiraUtil(jiraClient)
 
       await callback(context, jiraClient, util)
     }
-  }
+  })
 }

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -1,5 +1,3 @@
-const Sentry = require('@sentry/node')
-
 const { Subscription } = require('../models')
 const getJiraClient = require('../jira/client')
 const { getRepositorySummary } = require('./jobs')
@@ -80,9 +78,7 @@ module.exports.processInstallation = (app, queues) => {
   return async function (job) {
     const { installationId, jiraHost } = job.data
 
-    Sentry.setExtra('jobData', job.data)
-    Sentry.setTag('jiraHost', jiraHost)
-    Sentry.setUser({ gitHubInstallationId: installationId, jiraHost })
+    job.sentry.setUser({ gitHubInstallationId: installationId, jiraHost })
 
     app.log(`Starting job for installationId=${installationId}`)
 
@@ -134,16 +130,20 @@ module.exports.processInstallation = (app, queues) => {
           await jiraClient.devinfo.repository.update(jiraPayload)
         } catch (err) {
           if (err.response && err.response.status === 400) {
-            Sentry.setExtra('Response body', err.response.data.errorMessages)
-            Sentry.setExtra('Jira payload', err.response.data.jiraPayload)
+            job.sentry.setExtra('Response body', err.response.data.errorMessages)
+            job.sentry.setExtra('Jira payload', err.response.data.jiraPayload)
           }
 
           if (err.request) {
-            Sentry.setExtra('Request', { host: err.request.domain, path: err.request.path, method: err.request.method })
+            job.sentry.setExtra('Request', { host: err.request.domain, path: err.request.path, method: err.request.method })
           }
 
           if (err.response) {
-            Sentry.setExtra('Response', { status: err.response.status, statusText: err.response.statusText })
+            job.sentry.setExtra('Response', {
+              status: err.response.status,
+              statusText: err.response.statusText,
+              body: err.response.body
+            })
           }
 
           throw new Error(`Failed Jira API request: ${err.response.status}`)

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -42,22 +42,42 @@ Object.keys(queues).forEach(name => {
   queue.on('failed', async (job, err) => {
     app.log.error(`Error occurred while processing job id=${job.id} on queue name=${name}`)
 
-    Sentry.setTag('queue', name)
-    Sentry.setExtra('jobData', Object.assign(job.data, { id: job.id }))
-    Sentry.captureException(err)
-
     const subscription = await Subscription.getSingleInstallation(job.data.jiraHost, job.data.installationId)
     await subscription.update({ syncStatus: 'FAILED' })
   })
 })
 
+// Return an async function that assigns a Sentry hub to `job.sentry` and sends exceptions.
+const sentryMiddleware = function (jobHandler) {
+  return async (job) => {
+    job.sentry = new Sentry.Hub(Sentry.getCurrentHub().getClient())
+
+    try {
+      await jobHandler(job)
+    } catch (err) {
+      job.sentry.setExtra('job', {
+        id: job.id,
+        attemptsMade: job.attemptsMade,
+        timestamp: new Date(job.timestamp),
+        data: job.data
+      })
+
+      job.sentry.setTag('jiraHost', job.data.jiraHost)
+      job.sentry.setTag('queue', job.queue.name)
+      job.sentry.captureException(err)
+
+      throw err
+    }
+  }
+}
+
 module.exports = {
   queues,
 
   start () {
-    queues.discovery.process(5, discovery(app, queues))
-    queues.installation.process(Number(CONCURRENT_WORKERS), processInstallation(app, queues))
-    queues.push.process(Number(CONCURRENT_WORKERS), limiterPerInstallation(processPush(app)))
+    queues.discovery.process(5, sentryMiddleware(discovery(app, queues)))
+    queues.installation.process(Number(CONCURRENT_WORKERS), sentryMiddleware(processInstallation(app, queues)))
+    queues.push.process(Number(CONCURRENT_WORKERS), sentryMiddleware(limiterPerInstallation(processPush(app))))
     app.log(`Worker process started with ${CONCURRENT_WORKERS} CONCURRENT WORKERS`)
   },
 

--- a/test/setup/create-job.js
+++ b/test/setup/create-job.js
@@ -1,0 +1,16 @@
+// Create a job stub with data
+const createJob = ({ data, opts }) => {
+  const defaultOpts = {
+    attempts: 3,
+    removeOnFail: true,
+    removeOnComplete: true
+  }
+
+  return {
+    data: data,
+    opts: Object.assign(defaultOpts, opts || {}),
+    sentry: { setUser: () => { } }
+  }
+}
+
+module.exports = createJob

--- a/test/unit/sync/branch.test.js
+++ b/test/unit/sync/branch.test.js
@@ -84,7 +84,6 @@ describe('sync/branches', () => {
   let jiraApi
   let installationId
   let delay
-  let attempts = 3
 
   beforeEach(() => {
     const models = td.replace('../../../lib/models')

--- a/test/unit/sync/branch.test.js
+++ b/test/unit/sync/branch.test.js
@@ -1,6 +1,7 @@
 const nock = require('nock')
 const parseSmartCommit = require('../../../lib/transforms/smart-commit')
 const emptyNodesFixture = require('../../fixtures/api/graphql/branch-empty-nodes.json')
+const createJob = require('../../setup/create-job')
 
 function makeExpectedResponse ({branchName}) {
   const { issueKeys } = parseSmartCommit(branchName)
@@ -127,10 +128,7 @@ describe('sync/branches', () => {
   test('should sync to Jira when branch refs have jira references', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com')
       .post('/installations/1/access_tokens')
@@ -155,10 +153,7 @@ describe('sync/branches', () => {
   test('should send data if issue keys are only present in commits', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     const branchCommitsHaveKeys = require('../../fixtures/api/graphql/branch-commits-have-keys.json')
     nockBranchRequst(branchCommitsHaveKeys)
@@ -179,10 +174,7 @@ describe('sync/branches', () => {
   test('should send data if issue keys are only present in an associatd PR title', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     const associatedPRhasKeys = require('../../fixtures/api/graphql/branch-associated-pr-has-keys.json')
     nockBranchRequst(associatedPRhasKeys)
@@ -240,10 +232,7 @@ describe('sync/branches', () => {
   test('should not call Jira if no issue keys are found', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     const branchNoIssueKeys = require('../../fixtures/api/graphql/branch-no-issue-keys.json')
     nockBranchRequst(branchNoIssueKeys)

--- a/test/unit/sync/commits.test.js
+++ b/test/unit/sync/commits.test.js
@@ -1,5 +1,6 @@
 const nock = require('nock')
 const defaultBranchFixture = require('../../fixtures/api/graphql/default-branch.json')
+const createJob = require('../../setup/create-job')
 
 describe('sync/commits', () => {
   let jiraHost
@@ -7,7 +8,6 @@ describe('sync/commits', () => {
   let installationId
   let emptyNodesFixture
   let delay
-  let attempts = 3
 
   beforeEach(() => {
     const models = td.replace('../../../lib/models')
@@ -51,10 +51,7 @@ describe('sync/commits', () => {
   test('should sync to Jira when Commit Nodes have jira references', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -113,10 +110,7 @@ describe('sync/commits', () => {
   test('should send Jira all commits that have Issue Keys', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -209,10 +203,7 @@ describe('sync/commits', () => {
   test('should default to master branch if defaultBranchRef is null', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -272,10 +263,7 @@ describe('sync/commits', () => {
   test('should not call Jira if no issue keys are present', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { delay, attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -305,10 +293,7 @@ describe('sync/commits', () => {
   test('should not call Jira if no data is returned', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: { attempts, removeOnFail: true, removeOnComplete: true }
-    }
+    const job = createJob({ data: { installationId, jiraHost } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 

--- a/test/unit/sync/pull-requests.test.js
+++ b/test/unit/sync/pull-requests.test.js
@@ -1,4 +1,5 @@
 const nock = require('nock')
+const createJob = require('../../setup/create-job')
 
 describe('sync/pull-request', () => {
   let jiraHost
@@ -46,14 +47,8 @@ describe('sync/pull-request', () => {
   test('should sync to Jira when Pull Request Nodes have jira references', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: {
-        removeOnComplete: true,
-        removeOnFail: true,
-        attempts: 3
-      }
-    }
+    const job = createJob({ data: { installationId, jiraHost } })
+
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
     const { pullsNoLastCursor, pullsWithLastCursor } = require('../../fixtures/api/graphql/pull-queries')
@@ -114,14 +109,7 @@ describe('sync/pull-request', () => {
   test('should not sync if nodes are empty', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
 
-    const job = {
-      data: { installationId, jiraHost },
-      opts: {
-        removeOnComplete: true,
-        removeOnFail: true,
-        attempts: 3
-      }
-    }
+    const job = createJob({ data: { installationId, jiraHost } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 
@@ -151,15 +139,7 @@ describe('sync/pull-request', () => {
   test('should not sync if nodes do not contain issue keys', async () => {
     const { processInstallation } = require('../../../lib/sync/installation')
     process.env.LIMITER_PER_INSTALLATION = 2000
-    const job = {
-      data: { installationId, jiraHost },
-      opts: {
-        removeOnComplete: true,
-        removeOnFail: true,
-        attempts: 3,
-        delay: 2000
-      }
-    }
+    const job = createJob({ data: { installationId, jiraHost }, opts: { delay: 2000 } })
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' })
 


### PR DESCRIPTION
**Note:** This branches from https://github.com/integrations/jira/pull/242. For review, start at https://github.com/integrations/jira/pull/244/commits/31caab858499422a5134c95b63f175cf9f4a1391.

## Problem

Prior to this change, the error reporting for webhooks delivered by GitHub and handled by Probot had some shortcomings.

- **The user was identified by IP**, which pointed back to whatever server delivered the webhook. This isn’t meaningful information and made it difficult to tell who was impacted by the error.
- **Errors weren’t searchable.** Related to the first point, the errors had no meaningful tags to search against. I couldn’t filter errors by the type of webhook, the related Jira host, or the GitHub installation. Instead, errors were mixed together so long as the exception message looked the same.
- **Error context leaked to other requests.** This is most noticeable by looking at errors in Sentry that shouldn’t have a “GitHub Payload”. If a process sent a webhook error to Sentry and then processed a background job error, the webhook “GitHub Payload” would appear on the background job error in Sentry. This seems to be a bug in the bunyan stream.

This leaking goes both ways too. To illustrate this, follow these steps:

1. Add SENTRY_DSN to `.env`
2. Tweak `github/middleware.js` to throw an error so the webhook handling always fails
3. Start the app locally
4. Trigger a web frontend error: `curl -v https://jnraine-jira.ngrok.io/boom `
5. Modify a connect GitHub repo issue to trigger a webhook delivery

Once finished, there should be two new events in Sentry. The second, generated by the webhook delivery, will report the browser as `curl` even though it was delivered by GitHub.

## Solution

To address this, I’ve removed the Sentry bunyan stream and added custom Sentry error handling to the event middleware. This is done in a fashion similar to our background jobs (https://github.com/integrations/jira/pull/242).

With the new error handling in place, exceptions thrown while processing webhook events are tagged with the following data:

- _User_: jiraHost and gitHubInstallationId
- _Tag_: jiraHost
- _Tag_: gitHubInstallationId
- _Tag_: transaction (includes webhook event and action)
- _Extra_: A brief summary of the GitHub payload

![Screen Shot 2019-08-19 at 5 50 14 PM](https://user-images.githubusercontent.com/300976/63309295-17712d00-c2ab-11e9-9959-7d12247e5f92.png)

This unlocks greater debugging capabilities, particularly using the tags. Once shipped, we should be able to see all errors generated by a specific Jira host, errors generated while process issue comments, and more.

This also makes it easy to add additional context within each event handler by calling `context.sentry.addTag` or `context.sentry.addExtra`.
