### PR TITLE
Prevent transitions during initial sync

### DIFF
--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -107,8 +107,8 @@ module.exports = async (id, installationId, jiraHost) => {
         delete: (repositoryId) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}`, {
           fields: { _updateSequenceId: Date.now() }
         }),
-        update: (data, preventTransitions = false) => instance.post('/rest/devinfo/0.10/bulk', {
-          preventTransitions,
+        update: (data, options) => instance.post('/rest/devinfo/0.10/bulk', {
+          preventTransitions: (options && options.preventTransitions) || false,
           repositories: [data],
           properties: {
             installationId

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -107,8 +107,8 @@ module.exports = async (id, installationId, jiraHost) => {
         delete: (repositoryId) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}`, {
           fields: { _updateSequenceId: Date.now() }
         }),
-        update: (data) => instance.post('/rest/devinfo/0.10/bulk', {
-          preventTransitions: false,
+        update: (data, preventTransitions = false) => instance.post('/rest/devinfo/0.10/bulk', {
+          preventTransitions,
           repositories: [data],
           properties: {
             installationId

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -127,7 +127,7 @@ module.exports.processInstallation = (app, queues) => {
       const { edges, jiraPayload } = await execute()
       if (jiraPayload) {
         try {
-          await jiraClient.devinfo.repository.update(jiraPayload, true)
+          await jiraClient.devinfo.repository.update(jiraPayload, { preventTransitions: true })
         } catch (err) {
           if (err.response && err.response.status === 400) {
             job.sentry.setExtra('Response body', err.response.data.errorMessages)

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -127,7 +127,7 @@ module.exports.processInstallation = (app, queues) => {
       const { edges, jiraPayload } = await execute()
       if (jiraPayload) {
         try {
-          await jiraClient.devinfo.repository.update(jiraPayload)
+          await jiraClient.devinfo.repository.update(jiraPayload, true)
         } catch (err) {
           if (err.response && err.response.status === 400) {
             job.sentry.setExtra('Response body', err.response.data.errorMessages)

--- a/test/unit/sync/branch.test.js
+++ b/test/unit/sync/branch.test.js
@@ -6,7 +6,7 @@ const createJob = require('../../setup/create-job')
 function makeExpectedResponse ({branchName}) {
   const { issueKeys } = parseSmartCommit(branchName)
   return {
-    preventTransitions: false,
+    preventTransitions: true,
     repositories: [
       {
         branches: [
@@ -187,7 +187,7 @@ describe('sync/branches', () => {
     expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts)
 
     td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
-      preventTransitions: false,
+      preventTransitions: true,
       repositories: [
         {
           branches: [

--- a/test/unit/sync/commits.test.js
+++ b/test/unit/sync/commits.test.js
@@ -75,7 +75,7 @@ describe('sync/commits', () => {
     expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts)
 
     td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
-      preventTransitions: false,
+      preventTransitions: true,
       repositories: [
         {
           commits: [
@@ -134,7 +134,7 @@ describe('sync/commits', () => {
     expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts)
 
     td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
-      preventTransitions: false,
+      preventTransitions: true,
       repositories: [
         {
           commits: [
@@ -228,7 +228,7 @@ describe('sync/commits', () => {
     expect(queues.installation.add).toHaveBeenCalledWith(job.data, job.opts)
 
     td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
-      preventTransitions: false,
+      preventTransitions: true,
       repositories: [
         {
           commits: [

--- a/test/unit/sync/pull-requests.test.js
+++ b/test/unit/sync/pull-requests.test.js
@@ -70,7 +70,7 @@ describe('sync/pull-request', () => {
     await processInstallation(app, queues)(job)
 
     td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
-      preventTransitions: false,
+      preventTransitions: true,
       repositories: [
         {
           id: 'test-repo-id',


### PR DESCRIPTION
Closes https://github.com/integrations/jira/issues/192

This will ensure transitions are not called during initial sync. I've done this by changing the Jira client to allow a second parameter, which defaults to `false` (the original value), while passing `true` into the one call site where we send all payloads to a Jira instance during the initial sync jobs.