### PR TITLE
Make debugging in VS Code easy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to web",
+      "port": 9229
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to worker",
+      "port": 9230
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "repository": "https://github.com/integrations/jira.git",
   "scripts": {
     "ci": "npm test && npm run lint",
-    "dev": "nodemon --exec \"npm start\"",
-    "dev:worker": "nodemon --exec \"node bin/worker\"",
+    "dev": "nodemon --exec \"node --inspect ./lib/run.js\"",
+    "dev:worker": "nodemon --exec \"node --inspect=9230 bin/worker\"",
     "lint": "standard --fix",
     "es": "eslint",
     "start": "node ./lib/run.js",


### PR DESCRIPTION
Prior to this commit, I used these steps to debug in VS Code:

1. Add breakpoint
2. Stop server
3. Remove the “web” line from `Procfile.dev`
4. Run `script/server`
5. In VS Code Debugger sidebar, click “Start debugging” (the play icon)

Once I finished debugging, I needed to revert `Procfile.dev` and restart the server. This worked but was a pain. I found myself wishing for something as easy as a browser.

This commit reduces those steps to one: click “Start Debugging” in VS Code.

This is enabled by two changes: the web server is always started with `--inspect` and `.vs_code/launch.json` tells VS Code to look for a running debugger and attach instead of trying to start a server itself. If you want to debug the worker instead of the web process, select “Attach to worker” from the debugger config dropdown and then click the play icon.

I’ll follow-up with some developer documentation to make this accessible to anyone new on the project.