### PR TITLE
Improve logging

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -198,7 +198,7 @@ app.post('/:installationId/sync', bodyParser, async (req, res) => {
 
 app.get('/jira/:clientKey', bodyParser, async (request, response) => {
   const installation = await Installation.findOne({ where: { clientKey: request.params.clientKey } })
-  const jiraClient = new JiraClient(installation)
+  const jiraClient = new JiraClient(installation, request.log)
   const subscriptionSummary = (subscription) => {
     return {
       gitHubInstallationId: subscription.gitHubInstallationId,
@@ -223,7 +223,7 @@ app.post('/jira/:clientKey/uninstall', bodyParser, async (request, response) => 
   response.locals.installation = await Installation.findOne({ where: { clientKey: request.params.clientKey } })
 
   if (response.locals.installation) {
-    const jiraClient = new JiraClient(response.locals.installation)
+    const jiraClient = new JiraClient(response.locals.installation, request.log)
     const checkAuthorization = request.body.force !== 'true'
 
     if (checkAuthorization && jiraClient.isAuthorized()) {

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -6,7 +6,7 @@ const octokit = require('@octokit/rest')()
 
 const { Installation } = require('../models')
 const verifyInstallation = require('../jira/verify-installation')
-const logMiddlware = require('../middleware/log-middleware')
+const logMiddleware = require('../middleware/log-middleware')
 
 async function getInstallation (client, subscription) {
   const id = subscription.gitHubInstallationId
@@ -42,7 +42,7 @@ const viewerPermissionQuery = `{
 }
 `
 
-app.use(logMiddlware)
+app.use(logMiddleware)
 
 // All routes require a PAT to belong to someone on staff
 // This middleware will take the token and make a request to GraphQL
@@ -65,7 +65,7 @@ app.use(async (req, res, next) => {
       url: '/graphql'
     })).data
 
-    req.addLogFields({ login: data.viewer.login })
+    req.addLogFields({ login: (data && data.viewer && data.viewer.login) })
 
     if (errors) {
       res.status(401)

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -6,6 +6,7 @@ const octokit = require('@octokit/rest')()
 
 const { Installation } = require('../models')
 const verifyInstallation = require('../jira/verify-installation')
+const logMiddlware = require('../middleware/log-middleware')
 
 async function getInstallation (client, subscription) {
   const id = subscription.gitHubInstallationId
@@ -41,6 +42,8 @@ const viewerPermissionQuery = `{
 }
 `
 
+app.use(logMiddlware)
+
 // All routes require a PAT to belong to someone on staff
 // This middleware will take the token and make a request to GraphQL
 // to see if it belongs to somone on staff
@@ -62,14 +65,16 @@ app.use(async (req, res, next) => {
       url: '/graphql'
     })).data
 
+    req.addLogFields({ login: data.viewer.login })
+
     if (errors) {
       res.status(401)
       return res.json({ errors, viewerPermissionQuery })
     }
 
     if (!data.viewer.organization) {
-      console.log(`Non-github scoped token attempted to access staff routes`)
-      console.log(`login=${data.viewer.login}, isEmployee=${data.viewer.isEmployee}`)
+      req.log.info(`Non-GitHub scoped token attempted to access staff routes: login=${data.viewer.login}, isEmployee=${data.viewer.isEmployee}`)
+
       res.status(401)
       return res.json({
         error: 'Unauthorized',
@@ -78,8 +83,10 @@ app.use(async (req, res, next) => {
     }
 
     if (!validViewerPermission(data.viewer)) {
-      console.log(`User attempted to access staff routes`)
-      console.log(`login=${data.viewer.login}, isEmployee=${data.viewer.isEmployee}, viewerPermission=${data.viewer.organization.repository.viewerPermission}`)
+      req.log.info(
+        `User attempted to access staff routes: login=${data.viewer.login}, isEmployee=${data.viewer.isEmployee}, viewerPermission=${data.viewer.organization.repository.viewerPermission}`
+      )
+
       res.status(401)
       return res.json({
         error: 'Unauthorized',
@@ -87,12 +94,12 @@ app.use(async (req, res, next) => {
       })
     }
 
-    console.log(`Staff routes accessed:`)
-    console.log(`login=${data.viewer.login}, isEmployee=${data.viewer.isEmployee}, viewerPermission=${data.viewer.organization.repository.viewerPermission}`)
+    req.log.info(`Staff routes accessed: login=${data.viewer.login}, isEmployee=${data.viewer.isEmployee}, viewerPermission=${data.viewer.organization.repository.viewerPermission}`)
 
     next()
   } catch (err) {
-    console.log({err})
+    req.log.info({ err })
+
     if (err.code === 401) {
       res.status(401)
       return res.send(err)
@@ -126,7 +133,7 @@ app.get('/:installationId', async (req, res) => {
       }))
 
     const failedConnections = installations.filter(response => {
-      console.log(response.error)
+      req.log.error(response.error)
       return response.error
     })
     res.json({
@@ -138,7 +145,7 @@ app.get('/:installationId', async (req, res) => {
       repoSyncState: `${req.protocol}://${req.get('host')}/api/${installationId}/repoSyncState.json`
     })
   } catch (err) {
-    console.log(err)
+    req.log.error(err)
     res.status(500)
     return res.json(err)
   }
@@ -165,11 +172,11 @@ app.get('/:installationId/repoSyncState.json', async (req, res) => {
 app.post('/:installationId/sync', bodyParser, async (req, res) => {
   const { Subscription } = require('../models')
   const { installationId } = req.params
-  console.log(req.body)
+  req.log.info(req.body)
   const { jiraHost } = req.body
 
   try {
-    console.log(jiraHost, installationId)
+    req.log.info(jiraHost, installationId)
     const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
     if (!subscription) {
       return res.sendStatus(404)
@@ -183,7 +190,7 @@ app.post('/:installationId/sync', bodyParser, async (req, res) => {
       message: `Successfully (re)started sync for ${installationId}`
     })
   } catch (err) {
-    console.log(err)
+    req.log.info(err)
     return res.sendStatus(401)
   }
 })
@@ -225,7 +232,7 @@ app.post('/:installationId/migrate/:undo?', bodyParser, async (req, res) => {
   }
 
   const getJiraClient = require('../jira/client')
-  const jiraClient = await getJiraClient(null, installationId, jiraHost)
+  const jiraClient = await getJiraClient(jiraHost, installationId, req.log)
 
   try {
     if (req.params.undo) {

--- a/lib/frontend/app.js
+++ b/lib/frontend/app.js
@@ -3,6 +3,7 @@ const express = require('express')
 const path = require('path')
 const session = require('cookie-session')
 const csrf = require('csurf')
+const Sentry = require('@sentry/node')
 
 const oauth = require('./github-oauth')({
   githubClient: process.env.GITHUB_CLIENT_ID,
@@ -29,7 +30,7 @@ const verifyJiraMiddleware = require('./verify-jira-middleware')
 const retrySync = require('./retry-sync')
 
 const api = require('../api')
-const Sentry = require('@sentry/node')
+const logMiddleware = require('../middleware/log-middleware')
 
 module.exports = (appTokenGenerator) => {
   const githubClientMiddleware = getGithubClientMiddleware(appTokenGenerator)
@@ -53,6 +54,7 @@ module.exports = (appTokenGenerator) => {
     signed: true
   }))
 
+  app.use(logMiddleware)
   app.use(githubClientMiddleware)
 
   app.use('/api', api)
@@ -95,7 +97,7 @@ module.exports = (appTokenGenerator) => {
 
   app.get('/jira/configuration', csrfProtection, verifyJiraMiddleware, getJiraConfiguration)
   app.delete('/jira/configuration', verifyJiraMiddleware, deleteJiraConfiguration)
-  app.post('/jira/sync', csrfProtection, retrySync)
+  app.post('/jira/sync', csrfProtection, verifyJiraMiddleware, retrySync)
 
   app.get('/', async (req, res, next) => {
     const { data: info } = (await res.locals.client.apps.get({}))

--- a/lib/frontend/delete-github-subscription.js
+++ b/lib/frontend/delete-github-subscription.js
@@ -66,7 +66,7 @@ module.exports = async (req, res) => {
       })
     }
   } catch (err) {
-    console.log(err)
+    req.log.error(err)
     return res.sendStatus(400)
   }
 }

--- a/lib/frontend/delete-jira-configuration.js
+++ b/lib/frontend/delete-jira-configuration.js
@@ -4,7 +4,7 @@ const getJiraClient = require('../jira/client')
 module.exports = async (req, res) => {
   const jiraHost = req.query.xdm_e
 
-  const jiraClient = await getJiraClient(null, 'uninstalling', jiraHost)
+  const jiraClient = await getJiraClient(jiraHost, null, req.log)
   await jiraClient.devinfo.installation.delete(req.body.installationId)
 
   await Subscription.uninstall({

--- a/lib/frontend/get-github-configuration.js
+++ b/lib/frontend/get-github-configuration.js
@@ -45,7 +45,7 @@ module.exports = async (req, res, next) => {
     } catch (err) {
       // If we get here, there was either a problem decoding the JWT
       // or getting the data we need from GitHub, so we'll show the user an error.
-      console.log(err)
+      req.log.error(err)
       return next(err)
     }
   } else {

--- a/lib/frontend/retry-sync.js
+++ b/lib/frontend/retry-sync.js
@@ -1,27 +1,20 @@
-const { Installation, Subscription } = require('../models')
-const jwt = require('atlassian-jwt')
+const { Subscription } = require('../models')
 const Sentry = require('@sentry/node')
 
 module.exports = async (req, res, next) => {
-  const { jiraHost, installationId, token, syncType } = req.body
+  const installation = res.locals.installation
+
+  const { installationId: gitHubInstallationId, syncType } = req.body
 
   Sentry.setExtra('Body', req.body)
 
-  const installation = await Installation.getForHost(jiraHost)
+  try {
+    const subscription = await Subscription.getSingleInstallation(installation.jiraHost, gitHubInstallationId)
 
-  if (!installation) {
-    next(new Error('Not Found'))
-  } else {
-    try {
-      jwt.decode(token, installation.sharedSecret)
+    await Subscription.findOrStartSync(subscription, syncType)
 
-      const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
-
-      await Subscription.findOrStartSync(subscription, syncType)
-
-      return res.sendStatus(202)
-    } catch (error) {
-      next(new Error('Unauthorized'))
-    }
+    return res.sendStatus(202)
+  } catch (error) {
+    next(new Error('Unauthorized'))
   }
 }

--- a/lib/frontend/verify-jira-middleware.js
+++ b/lib/frontend/verify-jira-middleware.js
@@ -3,9 +3,16 @@ const jwt = require('atlassian-jwt')
 const { Installation } = require('../models')
 
 module.exports = async function verifyJiraRequest (req, res, next) {
-  const jiraHost = req.query.xdm_e
-  const token = req.query.jwt
+  const jiraHost = req.query.xdm_e || (req.body && req.body.jiraHost)
+  const token = req.query.jwt || (req.body && req.body.token)
+
   const installation = await Installation.getForHost(jiraHost)
+  res.locals.installation = installation
+
+  req.addLogFields({
+    jiraHost: installation.jiraHost,
+    jiraClientKey: installation.clientKey
+  })
 
   if (!installation) {
     next(new Error('Not Found'))

--- a/lib/frontend/verify-jira-middleware.js
+++ b/lib/frontend/verify-jira-middleware.js
@@ -3,20 +3,18 @@ const jwt = require('atlassian-jwt')
 const { Installation } = require('../models')
 
 module.exports = async function verifyJiraRequest (req, res, next) {
-  const jiraHost = req.query.xdm_e || (req.body && req.body.jiraHost)
-  const token = req.query.jwt || (req.body && req.body.token)
-
+  const jiraHost = (req.query && req.query.xdm_e) || (req.body && req.body.jiraHost)
+  const token = (req.query && req.query.jwt) || (req.body && req.body.token)
   const installation = await Installation.getForHost(jiraHost)
-  res.locals.installation = installation
 
-  req.addLogFields({
-    jiraHost: installation.jiraHost,
-    jiraClientKey: installation.clientKey
-  })
+  if (installation) {
+    res.locals.installation = installation
 
-  if (!installation) {
-    next(new Error('Not Found'))
-  } else {
+    req.addLogFields({
+      jiraHost: installation.jiraHost,
+      jiraClientKey: installation.clientKey
+    })
+
     try {
       // The JWT contains a `qsh` field that can be used to verify
       // the request body / query
@@ -27,5 +25,7 @@ module.exports = async function verifyJiraRequest (req, res, next) {
     } catch (error) {
       next(new Error('Unauthorized'))
     }
+  } else {
+    next(new Error('Not Found'))
   }
 }

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -44,10 +44,11 @@ module.exports = function middleware (callback) {
 
       context.sentry.setTag('jiraHost', jiraHost)
       context.sentry.setTag('gitHubInstallationId', gitHubInstallationId)
-
       context.sentry.setUser({ jiraHost, gitHubInstallationId })
 
-      const jiraClient = await getJiraClient(context.id, gitHubInstallationId, jiraHost)
+      context.log = context.log.child({ gitHubInstallationId, jiraHost })
+
+      const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, context.log)
       const util = getJiraUtil(jiraClient)
 
       await callback(context, jiraClient, util)

--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -2,8 +2,6 @@ const axios = require('axios')
 const jwt = require('atlassian-jwt')
 const url = require('url')
 
-const { logger } = require('probot/lib/logger')
-
 const instance = process.env.INSTANCE_NAME
 const iss = 'com.github.integration' + (instance ? `.${instance}` : '')
 
@@ -31,12 +29,10 @@ function getAuthMiddleware (secret) {
   }
 }
 
-function getErrorMiddleware (id, installationId) {
+function getErrorMiddleware (logger) {
   return (error) => {
     const { status, statusText } = error.response || {}
     logger.debug({
-      id,
-      installation: installationId,
       params: error.config.fields
     }, `Jira request: ${error.request.method} ${error.request.path} - ${status} ${statusText}`)
 
@@ -44,11 +40,9 @@ function getErrorMiddleware (id, installationId) {
   }
 }
 
-function getSuccessMiddleware (id, installationId) {
+function getSuccessMiddleware (logger) {
   return (response) => {
     logger.debug({
-      id,
-      installation: installationId,
       params: response.config.fields
     }, `Jira request: ${response.config.method.toUpperCase()} ${response.config.originalUrl} - ${response.status} ${response.statusText}`)
 
@@ -108,7 +102,7 @@ function getExpirationInSeconds () {
  * attempt to reuse them. This accomplished using Axios interceptors to
  * just-in-time add the token to a request before sending it.
  */
-module.exports = (id, installationId, baseURL, secret) => {
+module.exports = (baseURL, secret, logger) => {
   const instance = axios.create({
     baseURL,
     timeout: +process.env.JIRA_TIMEOUT || 20000
@@ -118,8 +112,8 @@ module.exports = (id, installationId, baseURL, secret) => {
   instance.interceptors.request.use(getUrlMiddleware())
 
   instance.interceptors.response.use(
-    getSuccessMiddleware(id, installationId),
-    getErrorMiddleware(id, installationId)
+    getSuccessMiddleware(logger),
+    getErrorMiddleware(logger)
   )
 
   return instance

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -114,7 +114,7 @@ module.exports = async (jiraHost, gitHubInstallationId, logger) => {
 
           if (!withinIssueKeyLimit(data.commits) || !withinIssueKeyLimit(data.branches)) {
             truncateIssueKeys(data)
-            const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
+            const subscription = await Subscription.getSingleInstallation(jiraHost, gitHubInstallationId)
             await subscription.update({syncWarning: 'Exceeded issue key reference limit. Some issues may not be linked.'})
           }
 

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -38,10 +38,9 @@ const withinIssueKeyLimit = (resources) => {
  * general, the client should match the Octokit rest.js design for clear
  * interoperability.
  */
-module.exports = async (id, installationId, jiraHost) => {
-  const { jiraHost: baseURL, sharedSecret: secret } = await Installation.getForHost(jiraHost)
-
-  const instance = getAxiosInstance(id, installationId, baseURL, secret)
+module.exports = async (jiraHost, gitHubInstallationId, logger) => {
+  const installation = await Installation.getForHost(jiraHost)
+  const instance = getAxiosInstance(installation.jiraHost, installation.sharedSecret, logger)
 
   const client = {
     baseURL: instance.defaults.baseURL,
@@ -153,7 +152,7 @@ module.exports = async (id, installationId, jiraHost) => {
               preventTransitions: (options && options.preventTransitions) || false,
               repositories: [data],
               properties: {
-                installationId
+                installationId: gitHubInstallationId
               }
             })
           } else {

--- a/lib/jira/index.js
+++ b/lib/jira/index.js
@@ -16,10 +16,15 @@ const authenticate = async (req, res, next) => {
     res.status(404).json({})
     return
   }
+
+  const { jiraHost, sharedSecret, clientKey } = installation
+
+  req.addLogFields({ jiraHost, jiraClientKey: clientKey })
   res.locals.installation = installation
-  const { jiraHost: baseUrl } = installation
-  if (!hasValidJwt(installation.sharedSecret, baseUrl, req, res)) return
-  next()
+
+  if (hasValidJwt(sharedSecret, jiraHost, req, res)) {
+    next()
+  }
 }
 
 module.exports = (robot) => {

--- a/lib/jira/verify-installation.js
+++ b/lib/jira/verify-installation.js
@@ -3,24 +3,24 @@ const Sentry = require('@sentry/node')
 
 module.exports = function (installation, log) {
   return async () => {
-    const instance = getAxiosInstance(null, {}, installation.jiraHost, installation.sharedSecret)
+    const instance = getAxiosInstance(installation.jiraHost, installation.sharedSecret, log)
 
     try {
       const result = await instance.get(`/rest/devinfo/0.10/existsByProperties?fakeProperty=1`)
       if (result.status === 200) {
-        log(`Installation id=${installation.id} enabled on Jira`)
+        log.info(`Installation id=${installation.id} enabled on Jira`)
         installation.enable()
       } else {
         const message = `Unable to verify Jira installation: ${installation.jiraHost} responded with ${result.status}`
-        log(message)
+        log.warn(message)
         Sentry.captureMessage(message)
       }
     } catch (err) {
       if (err.response && err.response.status === 401) {
-        log(`Jira does not recognize installation id=${installation.id}. Deleting it`)
+        log.warn(`Jira does not recognize installation id=${installation.id}. Deleting it`)
         installation.destroy()
       } else {
-        log(`Unhandled error while verifying installation id=${installation.id}: ${err}`)
+        log.error(`Unhandled error while verifying installation id=${installation.id}: ${err}`)
         Sentry.captureException(err)
       }
     }

--- a/lib/middleware/log-middleware.js
+++ b/lib/middleware/log-middleware.js
@@ -1,3 +1,5 @@
+const { logger } = require('probot/lib/logger')
+
 /*
 
 This enhances the existing request logger, created by Probot.
@@ -26,10 +28,11 @@ const logMiddleware = (req, res, next) => {
     if (this.log) {
       this.log = this.log.child(fields)
     } else {
-      throw new Error(`No log found: ${typeof this}`)
+      throw new Error(`No log found during request: ${req.method} ${req.path}`)
     }
   }
 
+  req.log = req.log || logger
   req.addLogFields({ requestId: req.header('X-Request-Id') })
 
   next()

--- a/lib/middleware/log-middleware.js
+++ b/lib/middleware/log-middleware.js
@@ -1,0 +1,38 @@
+/*
+
+This enhances the existing request logger, created by Probot.
+https://github.com/probot/probot/blob/e20d3ce8f188f8266d6c1ab71aa245c110a0a26f/src/middleware/logging.ts
+
+See an example of how to use this in your routes below. Once added, `userId` is included in subsequent log messages.
+
+```
+app.get('/foo', async (req, res) => {
+  req.addLogFields({ userId: req.params.userId })
+  req.log.info('Hello from foo') // INFO -- Hello from foo (userId=123)
+
+  try {
+    doThing()
+    res.status(200)
+  } catch (err) {
+    req.log.error('An error occurred') // ERROR -- An error occurred (userId=123)
+    res.status(500)
+  }
+})
+```
+
+*/
+const logMiddleware = (req, res, next) => {
+  req.addLogFields = function (fields) {
+    if (this.log) {
+      this.log = this.log.child(fields)
+    } else {
+      throw new Error(`No log found: ${typeof this}`)
+    }
+  }
+
+  req.addLogFields({ requestId: req.header('X-Request-Id') })
+
+  next()
+}
+
+module.exports = logMiddleware

--- a/lib/models/jira-client.js
+++ b/lib/models/jira-client.js
@@ -1,8 +1,8 @@
 const getAxiosInstance = require('../jira/client/axios')
 
 class JiraClient {
-  constructor (installation) {
-    this.axios = getAxiosInstance(null, {}, installation.jiraHost, installation.sharedSecret)
+  constructor (installation, log) {
+    this.axios = getAxiosInstance(installation.jiraHost, installation.sharedSecret, log)
   }
 
   /*

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -39,11 +39,11 @@ module.exports = class Subscription extends Sequelize.Model {
     })
   }
 
-  static async getSingleInstallation (host, installationId) {
+  static async getSingleInstallation (jiraHost, gitHubInstallationId) {
     return Subscription.findOne({
       where: {
-        jiraHost: host,
-        gitHubInstallationId: installationId
+        jiraHost,
+        gitHubInstallationId
       }
     })
   }

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -85,7 +85,7 @@ module.exports.processInstallation = (app, queues) => {
     const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
     if (!subscription) return
 
-    const jiraClient = await getJiraClient(subscription.id, installationId, subscription.jiraHost)
+    const jiraClient = await getJiraClient(subscription.jiraHost, installationId, app.log)
     const github = await getEnhancedGitHub(installationId)
 
     const nextTask = getNextTask(subscription)
@@ -144,9 +144,7 @@ module.exports.processInstallation = (app, queues) => {
               statusText: err.response.statusText,
               body: err.response.body
             })
-          }
 
-          if (err.response && err.response.status) {
             throw new Error(`Failed Jira API request: ${err.response.status}`)
           } else {
             throw err

--- a/lib/transforms/push.js
+++ b/lib/transforms/push.js
@@ -86,12 +86,7 @@ function processPush (app) {
 
     if (!subscription) return {}
 
-    const jiraClient = await getJiraClient(
-      subscription.id,
-      installationId,
-      subscription.jiraHost
-    )
-
+    const jiraClient = await getJiraClient(subscription.jiraHost, installationId, app.log)
     const github = await app.auth(installationId)
 
     const commits = await Promise.all(

--- a/test/models/jira-client.test.js
+++ b/test/models/jira-client.test.js
@@ -1,4 +1,5 @@
 const nock = require('nock')
+const { logger } = require('probot/lib/logger')
 
 const JiraClient = require('../../lib/models/jira-client')
 
@@ -6,7 +7,7 @@ describe(JiraClient, () => {
   describe('isAuthorized()', () => {
     const buildClient = ({ status }) => {
       const installation = { jiraHost: 'https://example.atlassian.net', sharedSecret: 'secret' }
-      const jiraClient = new JiraClient(installation)
+      const jiraClient = new JiraClient(installation, logger)
 
       nock('https://example.atlassian.net')
         .get('/rest/devinfo/0.10/existsByProperties?fakeProperty=1')

--- a/test/unit/api/api.test.js
+++ b/test/unit/api/api.test.js
@@ -109,9 +109,9 @@ describe('API', () => {
       return supertest(app)
         .get('/api')
         .set('Authorization', 'Bearer xxx')
-        .expect(401)
         .then(response => {
           expect(response.body).toMatchSnapshot()
+          expect(response.status).toEqual(401)
         })
     })
 

--- a/test/unit/github/middleware.test.js
+++ b/test/unit/github/middleware.test.js
@@ -1,3 +1,5 @@
+const { logger } = require('probot/lib/logger')
+
 const { Installation, Subscription } = require('../../../lib/models')
 const middleware = require('../../../lib/github/middleware')
 
@@ -11,7 +13,8 @@ describe('Probot event middleware', () => {
         payload: {
           sender: { type: 'not bot' },
           installation: { id: 1234 }
-        }
+        },
+        log: logger
       }
 
       Installation.getForHost = jest.fn((jiraHost) => {


### PR DESCRIPTION
This commit aims to improve the quality of log messages sent to Loggly in a few ways:

1. Adds `jiraHost` and `jiraClientKey` to logs on _most_ web requests (background jobs coming next)
2. Adds `req.addLogFields`, which allows additiona fields to be added
3. Converts some `console.log` calls to `req.log`

This is a first step towards addressing https://github.com/integrations/jira/issues/247. As an example of how this can help increase visibility, here's a log of someone requesting a sync retry before:

```
14:57:29.368Z  INFO http: POST /jira/sync 202 - 99.35 ms (id=4a0c79e0-079b-4b2f-831d-947c9b450352)

-- becomes -- (scroll) -->

14:55:30.741Z  INFO http: POST /jira/sync 202 - 52.39 ms (id=17b390bc-1a70-433c-9218-9ac5142ae003, jiraHost=https://jnraine.atlassian.net jiraClientKey=4f4d220837b26a347a4493812968d2c7e679b9b5c0eae709ea5a378ce179938f)
```