### PR TITLE
Log webhook event and action

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -6,6 +6,10 @@ const push = require('./push')
 const { createBranch, deleteBranch } = require('./branch')
 
 module.exports = (robot) => {
+  robot.on('*', (context) => {
+    context.log({ event: context.event, action: context.payload.action }, 'Event received')
+  })
+
   robot.on(['issue_comment.created', 'issue_comment.edited'], middleware(issueComment))
 
   robot.on(['issues.opened', 'issues.edited'], middleware(issue))


### PR DESCRIPTION
Every webhook from GitHub will now trigger a log message that includes the request ID, event, and action. This happens in addition to the other actions so behaviour should not change.

This is motivated by a bug causing certain webhook events to timeout. This will help us determine what kind of webhook tends to fail and help focus our debugging.

I would prefer to use timeout middleware, which not only reports on the error but also mitigates the problem by reducing the timeout from 30 seconds to 10 seconds. Unfortunately, I couldn't figure out a way to inject this before Probot initialized the Webhook middleware. Because the webhook middleware never calls `next()`, middleware added after it isn't called.

```javascript
const handleTimeout = function (req, res, next) {
  const tenSeconds = 10 * 1000

  res.setTimeout(tenSeconds, function () {
    if (process.env.DEBUG_TIMEOUTS) {
      req.log.warn({ query: req.query, body: req.body }, 'Request timed out')
    } else {
      req.log.warn('Request timed out')
    }

    res.sendStatus(500)
  })

  // next()
}
```