### PR TITLE
Add stafftools to test Jira authorization

### DIFF
--- a/bin/stafftools
+++ b/bin/stafftools
@@ -49,6 +49,12 @@ class JiraStaffTools < Thor
     output_json(response.body)
   end
 
+  desc "jira <client_key>", "Display installation for Jira instance"
+  def jira(client_key)
+    response = client.get("/api/jira/#{CGI.escape(client_key)}")
+    output_json(response.body)
+  end
+
   no_commands do
     def get_jira_host(git_hub_installation_id)
       data = JSON.parse(info_response(git_hub_installation_id))

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -6,6 +6,7 @@ const octokit = require('@octokit/rest')()
 
 const { Installation } = require('../models')
 const verifyInstallation = require('../jira/verify-installation')
+const JiraClient = require('../models/jira-client')
 
 async function getInstallation (client, subscription) {
   const id = subscription.gitHubInstallationId
@@ -186,6 +187,29 @@ app.post('/:installationId/sync', bodyParser, async (req, res) => {
     console.log(err)
     return res.sendStatus(401)
   }
+})
+
+app.get('/jira/:clientKey', bodyParser, async (request, response) => {
+  const installation = await Installation.findOne({where: {clientKey: request.params.clientKey}})
+  const jiraClient = new JiraClient(installation)
+  const subscriptionSummary = (subscription) => {
+    return {
+      gitHubInstallationId: subscription.gitHubInstallationId,
+      createdAt: subscription.createdAt,
+      updatedAt: subscription.updatedAt,
+      syncStatus: subscription.syncStatus
+    }
+  }
+
+  const data = {
+    clientKey: installation.clientKey,
+    host: installation.jiraHost,
+    enabled: installation.enabled,
+    authorized: (await jiraClient.isAuthorized()),
+    gitHubInstallations: (await installation.subscriptions()).map((subscription) => subscriptionSummary(subscription))
+  }
+
+  response.json(data)
 })
 
 app.post('/jira/:installationId/verify', bodyParser, async (req, response) => {

--- a/lib/models/installation.js
+++ b/lib/models/installation.js
@@ -112,6 +112,10 @@ module.exports = class Installation extends Sequelize.Model {
       }
     })
   }
+
+  async subscriptions () {
+    return Subscription.getAllForClientKey(this.clientKey)
+  }
 }
 
 module.exports.getHashedKey = getHashedKey

--- a/lib/models/jira-client.js
+++ b/lib/models/jira-client.js
@@ -1,0 +1,27 @@
+const getAxiosInstance = require('../jira/client/axios')
+
+class JiraClient {
+  constructor (installation) {
+    this.axios = getAxiosInstance(null, {}, installation.jiraHost, installation.sharedSecret)
+  }
+
+  /*
+   * Tests credentials by making a request to the Jira API
+   *
+   * @return {boolean} Returns true if client has access to Jira API
+   */
+  async isAuthorized () {
+    try {
+      const response = await this.axios.get(`/rest/devinfo/0.10/existsByProperties?fakeProperty=1`)
+      return response.status === 200
+    } catch (error) {
+      if (error.response) {
+        return false
+      } else {
+        throw error
+      }
+    }
+  }
+}
+
+module.exports = JiraClient

--- a/test/models/jira-client.test.js
+++ b/test/models/jira-client.test.js
@@ -1,0 +1,47 @@
+const nock = require('nock')
+
+const JiraClient = require('../../lib/models/jira-client')
+
+describe(JiraClient, () => {
+  describe('isAuthorized()', () => {
+    const buildClient = ({ status }) => {
+      const installation = { jiraHost: 'https://example.atlassian.net', sharedSecret: 'secret' }
+      const jiraClient = new JiraClient(installation)
+
+      nock('https://example.atlassian.net')
+        .get('/rest/devinfo/0.10/existsByProperties?fakeProperty=1')
+        .reply(status)
+
+      return jiraClient
+    }
+
+    it('is true when response is 200', async () => {
+      const jiraClient = buildClient({ status: 200 })
+
+      const isAuthorized = await jiraClient.isAuthorized()
+      expect(isAuthorized).toBe(true)
+    })
+
+    it('is false when response is 302', async () => {
+      const jiraClient = buildClient({ status: 302 })
+
+      const isAuthorized = await jiraClient.isAuthorized()
+      expect(isAuthorized).toBe(false)
+    })
+
+    it('is false when response is 403', async () => {
+      const jiraClient = buildClient({ status: 403 })
+
+      const isAuthorized = await jiraClient.isAuthorized()
+      expect(isAuthorized).toBe(false)
+    })
+
+    it('rethrows non-response errors', async () => {
+      const jiraClient = buildClient({ status: 200 })
+
+      jest.spyOn(jiraClient.axios, 'get').mockImplementation(() => { throw new Error('boom') })
+
+      await expect(jiraClient.isAuthorized()).rejects.toThrow('boom')
+    })
+  })
+})


### PR DESCRIPTION
**This builds on https://github.com/integrations/jira/pull/253.**

This allows a staff member to check the authorization status of a specific Jira installation.

```bash
$ bin/stafftools jira 682b4a8f798a480a99e51b04936332a2
{
  "clientKey": "682b4a8f798a480a99e51b04936332a2",
  "host": "https://example.atlassian.net",
  "enabled": true,
  "authorized": true, # <-- Important bit
  "gitHubInstallations": [
    {
      "gitHubInstallationId": 1234,
      "createdAt": "2019-08-26T19:49:41.023Z",
      "updatedAt": "2019-08-26T20:02:33.515Z",
      "syncStatus": “ACTIVE”
    }
  ]
}
```

This is being added to help diagnose exceptions. We see a number of 403s but aren't able to test the customer's Jira credentials to determine if they are always invalid or only in certain contexts.

As part of this, I’ve introduced a new class, called `JiraClient`. This class does very little right now but bit-by-bit, the functionality from `lib/jira/client/index.js` will be migrated into this object. Instead of adding to the existing one, I've opted to build up a new one that is more object-oriented. Along the way, code added to `JiraClient` should be fully tested.

This also adds `bin/stafftools migrate`. [See details](https://github.com/integrations/jira/commit/4f8ac74b6b87fa14e1b6c838b8e3fb5fefbc2d4e).