### PR TITLE
Make the source of Jira errors more obvious

### DIFF
--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -3,6 +3,7 @@ const jwt = require('atlassian-jwt')
 const url = require('url')
 
 const { logger } = require('probot/lib/logger')
+const JiraClientError = require('./jira-client-error')
 
 const instance = process.env.INSTANCE_NAME
 const iss = 'com.github.integration' + (instance ? `.${instance}` : '')
@@ -33,14 +34,18 @@ function getAuthMiddleware (secret) {
 
 function getErrorMiddleware (id, installationId) {
   return (error) => {
-    const { status, statusText } = error.response || {}
-    logger.debug({
-      id,
-      installation: installationId,
-      params: error.config.fields
-    }, `Jira request: ${error.request.method} ${error.request.path} - ${status} ${statusText}`)
+    if (error.response) {
+      const { status, statusText } = error.response || {}
+      logger.debug({
+        id,
+        installation: installationId,
+        params: error.config.fields
+      }, `Jira request: ${error.request.method} ${error.request.path} - ${status} ${statusText}`)
 
-    return Promise.reject(error)
+      return Promise.reject(new JiraClientError(error))
+    } else {
+      return Promise.reject(error)
+    }
   }
 }
 

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -40,7 +40,6 @@ const withinIssueKeyLimit = (resources) => {
  */
 module.exports = async (id, installationId, jiraHost) => {
   const { jiraHost: baseURL, sharedSecret: secret } = await Installation.getForHost(jiraHost)
-
   const instance = getAxiosInstance(id, installationId, baseURL, secret)
 
   const client = {
@@ -136,7 +135,7 @@ module.exports = async (id, installationId, jiraHost) => {
         delete: (repositoryId) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}`, {
           fields: { _updateSequenceId: Date.now() }
         }),
-        update: (data, options) => {
+        update: async (data, options) => {
           // Deduplicate issue keys in commits and branches before request
           if ('commits' in data) data.commits = dedupIssueKeys(data.commits)
           if ('branches' in data) {
@@ -149,7 +148,7 @@ module.exports = async (id, installationId, jiraHost) => {
           }
 
           if (withinIssueKeyLimit(data.commits) && withinIssueKeyLimit(data.branches)) {
-            instance.post('/rest/devinfo/0.10/bulk', {
+            await instance.post('/rest/devinfo/0.10/bulk', {
               preventTransitions: (options && options.preventTransitions) || false,
               repositories: [data],
               properties: {

--- a/lib/jira/client/jira-client-error.js
+++ b/lib/jira/client/jira-client-error.js
@@ -1,0 +1,18 @@
+/*
+ * An error wrapper that provides a more specific message for failed requests to the Jira API.
+ */
+class JiraClientError extends Error {
+  constructor (error) {
+    const { status, statusText } = error.response
+    const { method, path } = error.response.request
+    const message = `${method} ${path} responded with ${status} ${statusText}`
+
+    super(message)
+
+    this.response = error.response
+    this.name = this.constructor.name
+    Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+module.exports = JiraClientError

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -146,11 +146,7 @@ module.exports.processInstallation = (app, queues) => {
             })
           }
 
-          if (err.response && err.response.status) {
-            throw new Error(`Failed Jira API request: ${err.response.status}`)
-          } else {
-            throw err
-          }
+          throw err
         }
       }
       await updateJobStatus(jiraClient, job, edges, task, repositoryId)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6455,7 +6455,7 @@
     },
     "lru-cache": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
       "integrity": "sha1-tcvwFVbBaWb+vlTO7A+03JDfbCg=",
       "requires": {
         "pseudomap": "^1.0.1",


### PR DESCRIPTION
It’s usually not possible to trace an error back to it’s cause using Sentry. **If we don’t know how something happened, it’s difficult to fix it.**

## Background

Right now, the majority of our errors occur while making requests to Jira. When reported, the errors are grouped by stacktrace. Unfortunately, the stacktraces aren't helpful. For example:

```
Error: Request failed with status code 400
  File "/app/node_modules/axios/lib/core/createError.js", line 16, col 15, in createError
    var error = new Error(message);
  File "/app/node_modules/axios/lib/core/settle.js", line 18, col 12, in settle
    reject(createError(
  File "/app/node_modules/axios/lib/adapters/http.js", line 201, col 11, in IncomingMessage.handleStreamEnd
    settle(resolve, reject, response);
  File "events.js", line 214, col 15, in IncomingMessage.emit
  File "domain.js", line 476, col 20, in IncomingMessage.EventEmitter.emit
  File "_stream_readable.js", line 1178, col 12, in endReadableNT
  File "internal/process/task_queues.js", line 77, col 11, in processTicksAndRejectio
```

_👆None of our code appears in the stacktrace 😭_

Further, it doesn’t matter what path was requested or the response code.  As long as the stacktrace is the same, it’s grouped together. This makes it difficult to know what endpoints are most problematic and where in our code the requests originate from.

## Solution

This pull request aims to address this in a two ways:

1. **Using `await` when requesting `/rest/devinfo/0.10/bulk`.** Because we’re running Node 12, this causes our code to [appear in the stacktrace](https://thecodebarbarian.com/async-stack-traces-in-node-js-12). In order to use `await` with Axios, it has been updated to 0.19.

2. **`JiraClientError`, a custom error class,** has been created to improve the error message by using a more specific name and including the HTTP method, path and status in the message.

With this change, the stacktrace becomes more meaningful:

```
JiraClientError: POST /rest/devinfo/0.10/bulk1 responded with 404
  File "/Users/jordan/projects/jira/lib/jira/client/axios.js", line 58, col 27, in null.<anonymous>
    return Promise.reject(new JiraClientError(error))
  File "internal/process/task_queues.js", line 85, col 5, in processTicksAndRejections
  File "/Users/jordan/projects/jira/lib/jira/client/index.js", line 168, col 13, in async Object.update
    await instance.post('/rest/devinfo/0.10/bulk1', {
  File "/Users/jordan/projects/jira/lib/github/branch.js", line 13, col 3, in async module.exports.createBranch
    await jiraClient.devinfo.repository.update(jiraPayload)
  File "async /Users/jordan/projects/jira/lib/github/middleware.js", line 53, col 7, in null.<anonymous>
  File "async /Users/jordan/projects/jira/lib/github/middleware.js", line 14, col 7, in null.<anonymous>
```

And because the stacktrace includes our code, the errors from different areas of the codebase are grouped differently:

![image](https://user-images.githubusercontent.com/300976/63811165-91bd3500-c8db-11e9-8094-7dade4bd9ff9.png)
