### PR TITLE
Add “migrate” to stafftools

### DIFF
--- a/bin/stafftools
+++ b/bin/stafftools
@@ -48,6 +48,18 @@ class JiraStaffTools < Thor
 
     output_json(response.body)
   end
+  
+  desc "migrate <git_hub_installation_id>", "Mark as migrated from DVCS and set sync to COMPLETE"
+  def migrate(git_hub_installation_id)
+    jira_host = get_jira_host(git_hub_installation_id)
+
+    response = client.post(
+      "/api/#{CGI.escape(git_hub_installation_id)}/migrate",
+      "jiraHost" => jira_host
+    )
+
+    output_json(response.body)
+  end
 
   no_commands do
     def get_jira_host(git_hub_installation_id)


### PR DESCRIPTION
This endpoint allows us to manually mark a Jira installation as migrated with a successful sync. This is useful when a customer’s sync has sent all data to Jira but failed to tell Jira the migration was complete.