### PR TITLE
Truncate issue keys and show warning to user

### DIFF
--- a/db/migrations/20190828145758-add-sync-warning-column-on-subscriptions.js
+++ b/db/migrations/20190828145758-add-sync-warning-column-on-subscriptions.js
@@ -1,0 +1,12 @@
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Subscriptions', 'syncWarning', {
+      type: Sequelize.STRING,
+      allowNull: true
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Subscriptions', 'syncWarning')
+  }
+}

--- a/lib/frontend/get-jira-configuration.js
+++ b/lib/frontend/get-jira-configuration.js
@@ -7,6 +7,7 @@ async function getInstallation (client, subscription) {
   try {
     const response = await client.apps.getInstallation({ installation_id: id })
     response.data.syncStatus = subscription.isActiveSyncStalled() ? 'STALLED' : subscription.syncStatus
+    response.data.syncWarning = subscription.syncWarning
     response.data.subscriptionUpdatedAt = formatDate(subscription.updatedAt)
     return response.data
   } catch (err) {

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -1,4 +1,4 @@
-const { Installation } = require('../../models')
+const { Installation, Subscription } = require('../../models')
 const getAxiosInstance = require('./axios')
 const { getJiraId } = require('../util/id')
 
@@ -9,6 +9,16 @@ const ISSUE_KEY_API_LIMIT = 100
  * Deduplicates elements in an array
  */
 const dedup = (array) => [...new Set(array)]
+
+/**
+ * Truncates to first 100 issue keys for branch or commit
+ */
+const truncateIssueKeys = (resources) => {
+  resources.forEach(resource => {
+    resource.issueKeys = resource.issueKeys.slice(0, ISSUE_KEY_API_LIMIT)
+  })
+  return resources
+}
 
 /**
  * Deduplicates the issueKeys field for branches and commits
@@ -29,6 +39,22 @@ const withinIssueKeyLimit = (resources) => {
 
   const issueKeyCounts = resources.map((resource) => resource.issueKeys.length)
   return Math.max(...issueKeyCounts) <= ISSUE_KEY_API_LIMIT
+}
+
+/**
+ * Runs a mutating function on all branches and commits
+ * with issue keys in a Jira Repository object
+ */
+const updateRepositoryIssueKeys = (repositoryObj, updateFunc) => {
+  if ('commits' in repositoryObj) repositoryObj.commits = dedupIssueKeys(repositoryObj.commits)
+  if ('branches' in repositoryObj) {
+    repositoryObj.branches = updateFunc(repositoryObj.branches)
+    repositoryObj.branches.forEach(branch => {
+      if ('lastCommit' in branch) {
+        branch.lastCommit = updateFunc([branch.lastCommit])[0]
+      }
+    })
+  }
 }
 
 /*
@@ -136,30 +162,24 @@ module.exports = async (id, installationId, jiraHost) => {
         delete: (repositoryId) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}`, {
           fields: { _updateSequenceId: Date.now() }
         }),
-        update: (data, options) => {
+        update: async (data, options) => {
           // Deduplicate issue keys in commits and branches before request
-          if ('commits' in data) data.commits = dedupIssueKeys(data.commits)
-          if ('branches' in data) {
-            data.branches = dedupIssueKeys(data.branches)
-            data.branches.forEach(branch => {
-              if ('lastCommit' in branch) {
-                branch.lastCommit = dedupIssueKeys([branch.lastCommit])[0]
-              }
-            })
+          updateRepositoryIssueKeys(data, dedupIssueKeys)
+
+          if (!withinIssueKeyLimit(data.commits) || !withinIssueKeyLimit(data.branches)) {
+            // Truncate issue keys on all branches and commits to first 100 for Jira API limits
+            updateRepositoryIssueKeys(data, truncateIssueKeys)
+            const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
+            await subscription.update({syncWarning: 'Exceeded issue key reference limit. Some issues may not be linked.'})
           }
 
-          if (withinIssueKeyLimit(data.commits) && withinIssueKeyLimit(data.branches)) {
-            instance.post('/rest/devinfo/0.10/bulk', {
-              preventTransitions: (options && options.preventTransitions) || false,
-              repositories: [data],
-              properties: {
-                installationId
-              }
-            })
-          } else {
-            // We have more than 100 issue keys so raise an exception
-            throw new Error('A commit exceeded referenced issue key limit')
-          }
+          instance.post('/rest/devinfo/0.10/bulk', {
+            preventTransitions: (options && options.preventTransitions) || false,
+            repositories: [data],
+            properties: {
+              installationId
+            }
+          })
         }
       }
     }

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -5,58 +5,6 @@ const { getJiraId } = require('../util/id')
 // Max number of issue keys we can pass to the Jira API
 const ISSUE_KEY_API_LIMIT = 100
 
-/**
- * Deduplicates elements in an array
- */
-const dedup = (array) => [...new Set(array)]
-
-/**
- * Truncates to first 100 issue keys for branch or commit
- */
-const truncateIssueKeys = (resources) => {
-  resources.forEach(resource => {
-    resource.issueKeys = resource.issueKeys.slice(0, ISSUE_KEY_API_LIMIT)
-  })
-  return resources
-}
-
-/**
- * Deduplicates the issueKeys field for branches and commits
- */
-const dedupIssueKeys = (resources) => {
-  resources.forEach(resource => {
-    resource.issueKeys = dedup(resource.issueKeys)
-  })
-  return resources
-}
-
-/**
- * Returns if the max length of the issue
- * key field is within the limit
- */
-const withinIssueKeyLimit = (resources) => {
-  if (resources == null) return []
-
-  const issueKeyCounts = resources.map((resource) => resource.issueKeys.length)
-  return Math.max(...issueKeyCounts) <= ISSUE_KEY_API_LIMIT
-}
-
-/**
- * Runs a mutating function on all branches and commits
- * with issue keys in a Jira Repository object
- */
-const updateRepositoryIssueKeys = (repositoryObj, updateFunc) => {
-  if ('commits' in repositoryObj) repositoryObj.commits = dedupIssueKeys(repositoryObj.commits)
-  if ('branches' in repositoryObj) {
-    repositoryObj.branches = updateFunc(repositoryObj.branches)
-    repositoryObj.branches.forEach(branch => {
-      if ('lastCommit' in branch) {
-        branch.lastCommit = updateFunc([branch.lastCommit])[0]
-      }
-    })
-  }
-}
-
 /*
  * Similar to the existing Octokit rest.js instance included in probot
  * apps by default, this client adds a Jira client that allows us to
@@ -163,12 +111,10 @@ module.exports = async (id, installationId, jiraHost) => {
           fields: { _updateSequenceId: Date.now() }
         }),
         update: async (data, options) => {
-          // Deduplicate issue keys in commits and branches before request
-          updateRepositoryIssueKeys(data, dedupIssueKeys)
+          dedupIssueKeys(data)
 
           if (!withinIssueKeyLimit(data.commits) || !withinIssueKeyLimit(data.branches)) {
-            // Truncate issue keys on all branches and commits to first 100 for Jira API limits
-            updateRepositoryIssueKeys(data, truncateIssueKeys)
+            truncateIssueKeys(data)
             const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)
             await subscription.update({syncWarning: 'Exceeded issue key reference limit. Some issues may not be linked.'})
           }
@@ -187,3 +133,64 @@ module.exports = async (id, installationId, jiraHost) => {
 
   return client
 }
+
+/**
+ * Returns if the max length of the issue
+ * key field is within the limit
+ */
+const withinIssueKeyLimit = (resources) => {
+  if (resources == null) return []
+
+  const issueKeyCounts = resources.map((resource) => resource.issueKeys.length)
+  return Math.max(...issueKeyCounts) <= ISSUE_KEY_API_LIMIT
+}
+
+/**
+ * Deduplicates issueKeys field for branches and commits
+ */
+const dedupIssueKeys = (repositoryObj) => {
+  updateRepositoryIssueKeys(repositoryObj, dedup)
+}
+
+/**
+ * Truncates branches and commits to first 100 issue keys for branch or commit
+ */
+const truncateIssueKeys = (repositoryObj) => {
+  updateRepositoryIssueKeys(repositoryObj, truncate)
+}
+
+/**
+ * Runs a mutating function on all branches and commits
+ * with issue keys in a Jira Repository object
+ */
+const updateRepositoryIssueKeys = (repositoryObj, mutatingFunc) => {
+  if ('commits' in repositoryObj) repositoryObj.commits = updateIssueKeysFor(repositoryObj.commits, mutatingFunc)
+  if ('branches' in repositoryObj) {
+    repositoryObj.branches = updateIssueKeysFor(repositoryObj.branches, mutatingFunc)
+    repositoryObj.branches.forEach(branch => {
+      if ('lastCommit' in branch) {
+        branch.lastCommit = updateIssueKeysFor([branch.lastCommit], mutatingFunc)[0]
+      }
+    })
+  }
+}
+
+/**
+ * Runs the mutatingFunc on the issue keys field for each branch or commit
+ */
+const updateIssueKeysFor = (resources, mutatingFunc) => {
+  resources.forEach(resource => {
+    resource.issueKeys = mutatingFunc(resource.issueKeys)
+  })
+  return resources
+}
+
+/**
+ * Deduplicates elements in an array
+ */
+const dedup = (array) => [...new Set(array)]
+
+/**
+ * Truncates to 100 elements in an array
+ */
+const truncate = (array) => array.slice(0, ISSUE_KEY_API_LIMIT)

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -118,7 +118,7 @@ module.exports = async (id, installationId, jiraHost) => {
             await subscription.update({syncWarning: 'Exceeded issue key reference limit. Some issues may not be linked.'})
           }
 
-         await instance.post('/rest/devinfo/0.10/bulk', {
+          await instance.post('/rest/devinfo/0.10/bulk', {
             preventTransitions: (options && options.preventTransitions) || false,
             repositories: [data],
             properties: {

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -9,6 +9,7 @@ module.exports = class Subscription extends Sequelize.Model {
         selectedRepositories: DataTypes.ARRAY(DataTypes.INTEGER),
         repoSyncState: DataTypes.JSONB,
         syncStatus: DataTypes.ENUM('PENDING', 'COMPLETE', 'ACTIVE', 'FAILED'),
+        syncWarning: DataTypes.STRING,
         jiraClientKey: DataTypes.STRING
       },
       { sequelize }
@@ -91,6 +92,7 @@ module.exports = class Subscription extends Sequelize.Model {
     if (!repoSyncState || (syncType === 'full')) {
       await subscription.update({
         syncStatus: 'PENDING',
+        syncWarning: '',
         repoSyncState: {
           installationId,
           jiraHost,

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -86,3 +86,11 @@
   text-decoration: none;
   cursor: pointer;
 }
+
+.muted-link {
+  color: #586069 !important;
+}
+.muted-link:hover {
+  color: #0366d6 !important;
+  text-decoration: none;
+}

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -81,6 +81,9 @@
                     </td>
                     <td>
                       <span id="{{id}}-status"> {{ syncStatus }} </span>
+                      {{#if syncWarning}}
+                        <a href="#trigger" data-ak-tooltip="{{ syncWarning }}" data-ak-tooltip-position="top">⚠️</a>
+                      {{/if}}
                     </td>
                     <td>
                       <span title="{{ subscriptionUpdatedAt.absolute }}">

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -80,11 +80,12 @@
                       <a class="ak-button ak-button__appearance-link configure-connection-link" href="{{ html_url }}" data-installation-link="{{ html_url }}" target="_blank">Configure</a>
                     </td>
                     <td>
-                      <span id="{{id}}-status"> {{ syncStatus }} </span>
                       {{#if syncWarning}}
-                        <a href="#trigger" data-ak-tooltip="{{ syncWarning }}" data-ak-tooltip-position="top">
-                          <span id="{{id}}-status">{{ syncStatus }}</span>*
+                        <a href="#trigger" data-ak-tooltip="{{ syncWarning }}" data-ak-tooltip-position="top" class="muted-link">
+                          <span id="{{id}}-status"> {{ syncStatus }} </span>*
                         </a>
+                      {{else}}
+                        <span id="{{id}}-status"> {{ syncStatus }} </span>
                       {{/if}}
                     </td>
                     <td>

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -82,7 +82,9 @@
                     <td>
                       <span id="{{id}}-status"> {{ syncStatus }} </span>
                       {{#if syncWarning}}
-                        <a href="#trigger" data-ak-tooltip="{{ syncWarning }}" data-ak-tooltip-position="top">⚠️</a>
+                        <a href="#trigger" data-ak-tooltip="{{ syncWarning }}" data-ak-tooltip-position="top">
+                          <span id="{{id}}-status">{{ syncStatus }}</span>*
+                        </a>
                       {{/if}}
                     </td>
                     <td>


### PR DESCRIPTION
This PR limits the issue keys referenced from a commit or branch to the first 100. In #250 we started deduplicating the issue keys and throwing an error if there were more than 100. Instead of throwing an error, now we truncate the list of issue keys and display a warning to the user after the sync is complete.

![image](https://user-images.githubusercontent.com/7866060/63914415-bfe46700-c9f8-11e9-865b-c9195107eceb.gif)
