### PR TITLE
Remove Jira client “fields” path interpolation

### DIFF
--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -1,5 +1,6 @@
 const axios = require('axios')
 const jwt = require('atlassian-jwt')
+const querystring = require('querystring')
 const url = require('url')
 
 const { logger } = require('probot/lib/logger')
@@ -7,38 +8,37 @@ const { logger } = require('probot/lib/logger')
 const instance = process.env.INSTANCE_NAME
 const iss = 'com.github.integration' + (instance ? `.${instance}` : '')
 
+/*
+ * Create an Atlassian request from an Axios config.
+ * Compatible with jwt.createQueryStringHash.
+ */
+jwt.reqFromAxiosConfig = (config) => {
+  const parsedUrl = url.parse(config.url)
+  const parsedQuery = querystring.parse(parsedUrl.query)
+
+  return {
+    method: config.method,
+    originalUrl: parsedUrl.pathname,
+    query: Object.assign(parsedQuery, config.params)
+  }
+}
+
 function getAuthMiddleware (secret) {
   return (config) => {
-    const { query, pathname } = url.parse(config.url, true)
+    const qsh = jwt.createQueryStringHash(jwt.reqFromAxiosConfig(config))
+    const jwtToken = jwt.encode({ ...getExpirationInSeconds(), iss, qsh }, secret)
 
-    const jwtToken = jwt.encode({
-      ...getExpirationInSeconds(),
-      iss,
-      qsh: jwt.createQueryStringHash({
-        method: config.method,
-        originalUrl: pathname,
-        query
-      })
-    }, secret)
+    config.headers['Authorization'] = `JWT ${jwtToken}`
 
-    return {
-      ...config,
-      headers: {
-        ...config.headers,
-        Authorization: `JWT ${jwtToken}`
-      }
-    }
+    return config
   }
 }
 
 function getErrorMiddleware (id, installationId) {
   return (error) => {
-    const { status, statusText } = error.response || {}
-    logger.debug({
-      id,
-      installation: installationId,
-      params: error.config.fields
-    }, `Jira request: ${error.request.method} ${error.request.path} - ${status} ${statusText}`)
+    if (error.response) {
+      logResponse(id, installationId, error.response)
+    }
 
     return Promise.reject(error)
   }
@@ -46,41 +46,16 @@ function getErrorMiddleware (id, installationId) {
 
 function getSuccessMiddleware (id, installationId) {
   return (response) => {
-    logger.debug({
-      id,
-      installation: installationId,
-      params: response.config.fields
-    }, `Jira request: ${response.config.method.toUpperCase()} ${response.config.originalUrl} - ${response.status} ${response.statusText}`)
-
+    logResponse(id, installationId, response)
     return response
   }
 }
 
-function getUrlMiddleware () {
-  return (config) => {
-    let { query, pathname, ...rest } = url.parse(config.url, true)
-    config.fields = config.fields || {}
+const logResponse = function (id, installationId, response) {
+  const { status, statusText } = response
+  const { method, path } = response.request
 
-    for (let field in config.fields) {
-      if (pathname.includes(`:${field}`)) {
-        pathname = pathname.replace(`:${field}`, config.fields[field])
-      } else {
-        query[field] = config.fields[field]
-      }
-    }
-
-    config.fields['baseUrl'] = config.baseURL
-
-    return {
-      ...config,
-      originalUrl: config.url,
-      url: url.format({
-        ...rest,
-        pathname,
-        query
-      })
-    }
-  }
+  logger.debug({ id, installation: installationId }, `Jira request: ${method} ${path} - ${status} ${statusText}`)
 }
 
 /*
@@ -115,7 +90,6 @@ module.exports = (id, installationId, baseURL, secret) => {
   })
 
   instance.interceptors.request.use(getAuthMiddleware(secret))
-  instance.interceptors.request.use(getUrlMiddleware())
 
   instance.interceptors.response.use(
     getSuccessMiddleware(id, installationId),

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -1,3 +1,4 @@
+const qs = require('querystring')
 const { Installation } = require('../../models')
 const getAxiosInstance = require('./axios')
 const { getJiraId } = require('../util/id')
@@ -47,7 +48,7 @@ module.exports = async (id, installationId, jiraHost) => {
     baseURL: instance.defaults.baseURL,
     issues: {
       get: (issueId, params = { fields: 'summary' }) => {
-        return instance.get(`/rest/api/latest/issue/${issueId}`, { params })
+        return instance.get(`/rest/api/latest/issue/${qs.escape(issueId)}`, { params })
       },
       getAll: async (issueIds, query) => (await Promise.all(issueIds.map(issueId => client.issues.get(issueId, query).catch(error => error))))
         .filter(response => response.status === 200)
@@ -58,31 +59,33 @@ module.exports = async (id, installationId, jiraHost) => {
         return text.match(jiraIssueRegex)
       },
       comments: {
-        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${issueId}/comment`),
-        addForIssue: (issueId, payload) => instance.post(`/rest/api/latest/issue/:${issueId}/comment`, payload)
+        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${qs.escape(issueId)}/comment`),
+        addForIssue: (issueId, payload) => instance.post(`/rest/api/latest/issue/:${qs.escape(issueId)}/comment`, payload)
       },
       transitions: {
-        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${issueId}/transitions`),
+        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${qs.escape(issueId)}/transitions`),
         updateForIssue: (issueId, transitionId) => {
-          return instance.post(`/rest/api/latest/issue/${issueId}/transitions`, { transition: { id: transitionId } })
+          return instance.post(`/rest/api/latest/issue/${qs.escape(issueId)}/transitions`, { transition: { id: transitionId } })
         }
       },
       worklogs: {
-        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${issueId}/worklog`),
-        addForIssue: (issueId, payload) => instance.post(`/rest/api/latest/issue/${issueId}/worklog`, payload)
+        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${qs.escape(issueId)}/worklog`),
+        addForIssue: (issueId, payload) => instance.post(`/rest/api/latest/issue/${qs.escape(issueId)}/worklog`, payload)
       }
     },
     devinfo: {
       branch: {
         delete: (repositoryId, branchRef) => {
-          const path = `/rest/devinfo/0.10/repository/${repositoryId}/branch/${getJiraId(branchRef)}`
+          const jiraId = getJiraId(branchRef)
+          const path = `/rest/devinfo/0.10/repository/${qs.escape(repositoryId)}/branch/${qs.escape(jiraId)}`
+
           return instance.delete(path, { params: { _updateSequenceId: Date.now() } })
         }
       },
       // Add methods for handling installationId properties that exist in Jira
       installation: {
-        exists: (gitHubInstallationId) => instance.get(`/rest/devinfo/0.10/existsByProperties?installationId=${gitHubInstallationId}`),
-        delete: (gitHubInstallationId) => instance.delete(`/rest/devinfo/0.10/bulkByProperties?installationId=${gitHubInstallationId}`)
+        exists: (gitHubInstallationId) => instance.get(`/rest/devinfo/0.10/existsByProperties`, { params: { installationId: gitHubInstallationId } }),
+        delete: (gitHubInstallationId) => instance.delete(`/rest/devinfo/0.10/bulkByProperties`, { params: { installationId: gitHubInstallationId } })
       },
       // Migration endpoints do not take any parameters,
       // but return 500 errors if the body is empty or null.
@@ -93,14 +96,14 @@ module.exports = async (id, installationId, jiraHost) => {
       },
       pullRequest: {
         delete: (repositoryId, number) => {
-          const path = `/rest/devinfo/0.10/repository/${repositoryId}/pull_request/${number}`
+          const path = `/rest/devinfo/0.10/repository/${qs.escape(repositoryId)}/pull_request/${qs.escape(number)}`
           return instance.delete(path, { params: { _updateSequenceId: Date.now() } })
         }
       },
       repository: {
-        get: (repositoryId) => instance.get(`/rest/devinfo/0.10/repository/${repositoryId}`),
+        get: (repositoryId) => instance.get(`/rest/devinfo/0.10/repository/${qs.escape(repositoryId)}`),
         delete: (repositoryId) => {
-          const path = `/rest/devinfo/0.10/repository/${repositoryId}`
+          const path = `/rest/devinfo/0.10/repository/${qs.escape(repositoryId)}`
           return instance.delete(path, { params: { _updateSequenceId: Date.now() } })
         },
         update: async (data, options) => {

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -46,13 +46,9 @@ module.exports = async (id, installationId, jiraHost) => {
   const client = {
     baseURL: instance.defaults.baseURL,
     issues: {
-      // eslint-disable-next-line camelcase
-      get: (issue_id, query = { fields: 'summary' }) => instance.get(`/rest/api/latest/issue/:issue_id`, {
-        fields: {
-          ...query,
-          issue_id
-        }
-      }),
+      get: (issueId, params = { fields: 'summary' }) => {
+        return instance.get(`/rest/api/latest/issue/${issueId}`, { params })
+      },
       getAll: async (issueIds, query) => (await Promise.all(issueIds.map(issueId => client.issues.get(issueId, query).catch(error => error))))
         .filter(response => response.status === 200)
         .map(response => response.data),
@@ -62,57 +58,26 @@ module.exports = async (id, installationId, jiraHost) => {
         return text.match(jiraIssueRegex)
       },
       comments: {
-        // eslint-disable-next-line camelcase
-        getForIssue: (issue_id) => instance.get(`/rest/api/latest/issue/:issue_id/comment`, {
-          fields: {
-            issue_id
-          }
-        }),
-        // eslint-disable-next-line camelcase
-        addForIssue: (issue_id, payload) => instance.post(`/rest/api/latest/issue/:issue_id/comment`, payload, {
-          fields: {
-            issue_id
-          }
-        })
+        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${issueId}/comment`),
+        addForIssue: (issueId, payload) => instance.post(`/rest/api/latest/issue/:${issueId}/comment`, payload)
       },
       transitions: {
-        // eslint-disable-next-line camelcase
-        getForIssue: (issue_id) => instance.get(`/rest/api/latest/issue/:issue_id/transitions`, {
-          fields: {
-            issue_id
-          }
-        }),
-        // eslint-disable-next-line camelcase
-        updateForIssue: (issue_id, transition_id) => instance.post(`/rest/api/latest/issue/:issue_id/transitions`, {
-          transition: {
-            id: transition_id
-          }
-        }, {
-          fields: {
-            issue_id
-          }
-        })
+        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${issueId}/transitions`),
+        updateForIssue: (issueId, transitionId) => {
+          return instance.post(`/rest/api/latest/issue/${issueId}/transitions`, { transition: { id: transitionId } })
+        }
       },
       worklogs: {
-        // eslint-disable-next-line camelcase
-        getForIssue: (issue_id) => instance.get(`/rest/api/latest/issue/:issue_id/worklog`, {
-          fields: {
-            issue_id
-          }
-        }),
-        // eslint-disable-next-line camelcase
-        addForIssue: (issue_id, payload) => instance.post(`/rest/api/latest/issue/:issue_id/worklog`, payload, {
-          fields: {
-            issue_id
-          }
-        })
+        getForIssue: (issueId) => instance.get(`/rest/api/latest/issue/${issueId}/worklog`),
+        addForIssue: (issueId, payload) => instance.post(`/rest/api/latest/issue/${issueId}/worklog`, payload)
       }
     },
     devinfo: {
       branch: {
-        delete: (repositoryId, branchRef) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}/branch/${getJiraId(branchRef)}`, {
-          fields: { _updateSequenceId: Date.now() }
-        })
+        delete: (repositoryId, branchRef) => {
+          const path = `/rest/devinfo/0.10/repository/${repositoryId}/branch/${getJiraId(branchRef)}`
+          return instance.delete(path, { params: { _updateSequenceId: Date.now() } })
+        }
       },
       // Add methods for handling installationId properties that exist in Jira
       installation: {
@@ -127,16 +92,18 @@ module.exports = async (id, installationId, jiraHost) => {
         undo: () => instance.post('/rest/devinfo/0.10/github/undoMigration', {})
       },
       pullRequest: {
-        delete: (repositoryId, number) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}/pull_request/${number}`, {
-          fields: { _updateSequenceId: Date.now() }
-        })
+        delete: (repositoryId, number) => {
+          const path = `/rest/devinfo/0.10/repository/${repositoryId}/pull_request/${number}`
+          return instance.delete(path, { params: { _updateSequenceId: Date.now() } })
+        }
       },
       repository: {
         get: (repositoryId) => instance.get(`/rest/devinfo/0.10/repository/${repositoryId}`),
-        delete: (repositoryId) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}`, {
-          fields: { _updateSequenceId: Date.now() }
-        }),
-        update: (data, options) => {
+        delete: (repositoryId) => {
+          const path = `/rest/devinfo/0.10/repository/${repositoryId}`
+          return instance.delete(path, { params: { _updateSequenceId: Date.now() } })
+        },
+        update: async (data, options) => {
           // Deduplicate issue keys in commits and branches before request
           if ('commits' in data) data.commits = dedupIssueKeys(data.commits)
           if ('branches' in data) {


### PR DESCRIPTION
**Note: this change is in preparation for the Axios 0.19 update.**

Prior to this commit, there was an interceptor that added something similar to [Express.js route parameters] to Axios.

Looking at the [PR that introduced it], it was introduced to add debug logging. However, there is a problem: as of version 0.19, [Axios strips out unexpected key/value pairs] passed to the request methods like `get` and `post`.

This commit removes that interceptor and replaces the code with vanilla Axios code, interpolating values into the path or using `params`. This changes the debug logs, though

```
Jira request: GET /rest/api/latest/issue/:issue_id?fields=summary - 200  (id=47084f00-c934-11e9-9c6b-1691d649534a, installation=1339471)
{
  baseURL: “https://jnraine.atlassian.net”,
  fields: “summary”,
  issue_id: “WS-1”
}

-- becomes 👇

Jira request: GET /rest/api/latest/issue/WS-1?fields=summary - 200  (id=47084f00-c934-11e9-9c6b-1691d649534a, installation=1339471)
```

It’s more terse but I think it’s still useful. The only information we lose is the Jira host. Since these logs are development only, you likely already know what Jira host you’re using.

As a bonus, there are no more `eslint-disable-next-line camelcase` exceptions in this file. 🤗

[Express.js route parameters]: https://expressjs.com/en/guide/routing.html#route-parameters
[PR that introduced it]: https://github.com/integrations/jira/pull/12
[Axios strips out unexpected key/value pairs]: https://github.com/axios/axios/compare/v0.18.0...v0.19.0#diff-a3c2b8d114f9b727107446e1d3fd9847