### PR TITLE
Continue processing webhooks when error occurs

### DIFF
--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -50,7 +50,11 @@ module.exports = function middleware (callback) {
       const jiraClient = await getJiraClient(context.id, gitHubInstallationId, jiraHost)
       const util = getJiraUtil(jiraClient)
 
-      await callback(context, jiraClient, util)
+      try {
+        await callback(context, jiraClient, util)
+      } catch (err) {
+        context.sentry.captureException(err)
+      }
     }
   })
 }

--- a/test/unit/github/middleware.test.js
+++ b/test/unit/github/middleware.test.js
@@ -1,0 +1,49 @@
+const { Installation, Subscription } = require('../../../lib/models')
+const middleware = require('../../../lib/github/middleware')
+
+describe('Probot event middleware', () => {
+  describe('when processing fails for one subscription', () => {
+    let context
+    let handlerCalls
+
+    beforeEach(async () => {
+      context = {
+        payload: {
+          sender: { type: 'not bot' },
+          installation: { id: 1234 }
+        }
+      }
+
+      Installation.getForHost = jest.fn((jiraHost) => {
+        const installations = [
+          { jiraHost: 'https://foo.atlassian.net', sharedSecret: 'secret1' },
+          { jiraHost: 'https://bar.atlassian.net', sharedSecret: 'secret2' },
+          { jiraHost: 'https://baz.atlassian.net', sharedSecret: 'secret3' }
+        ]
+
+        return installations.find(installation => installation.jiraHost === jiraHost)
+      })
+
+      Subscription.getAllForInstallation = jest.fn().mockReturnValue([
+        { jiraHost: 'https://foo.atlassian.net' },
+        { jiraHost: 'https://bar.atlassian.net' },
+        { jiraHost: 'https://baz.atlassian.net' }
+      ])
+
+      handlerCalls = []
+      const handler = middleware((context, jiraClient, util) => {
+        handlerCalls.push([context, jiraClient, util])
+
+        if (handlerCalls.length === 1) {
+          throw Error('boom')
+        }
+      })
+
+      await handler(context)
+    })
+
+    it('calls handler for each subscription', async () => {
+      expect(handlerCalls.length).toEqual(3)
+    })
+  })
+})


### PR DESCRIPTION
A customer can connect multiple Jira instances to a GitHub organization. When they do so, GitHub delivers the event as a webhook that we process and fan out to each Jira instance.

![Screen Shot 2019-08-29 at 2 27 17 PM](https://user-images.githubusercontent.com/300976/63977677-40db4700-ca69-11e9-9b43-645522a3aea8.png)

If something goes wrong while processing the event for one of the Jira instances, like an HTTP error, we stop processing and throw an error. This can result in events being lost.

![Screen Shot 2019-08-29 at 2 27 23 PM](https://user-images.githubusercontent.com/300976/63977785-81d35b80-ca69-11e9-89a6-6099847a7bda.png)

To avoid this, we process each event within a `try … catch`. If something goes wrong, we send it to Sentry and continue processing.

![Screen Shot 2019-08-29 at 2 27 28 PM](https://user-images.githubusercontent.com/300976/63977793-8861d300-ca69-11e9-87f2-b6607a077ca8.png)
