### PR TITLE
Add ability to uninstall Jira installation via stafftools

### DIFF
--- a/bin/stafftools
+++ b/bin/stafftools
@@ -67,6 +67,30 @@ class JiraStaffTools < Thor
     output_json(response.body)
   end
 
+  desc "jira-uninstall <client_key>", "Uninstall the Jira instance"
+  long_desc <<~DESC
+    Trigger the same uninstall process that occurs when a customer
+    uninstalls the GitHub for Jira Atlassian Marketplace app.
+    
+    Note: this does not uninstall the app from a customer's Jira
+          instance, it only removes the data from our side.
+  DESC
+  option :force, type: :boolean, desc: "Force uninstall for an authorized Jira installation"
+  def jira_uninstall(client_key)
+    response = client.post("/api/jira/#{CGI.escape(client_key)}/uninstall", {force: options[:force]})
+    output =
+      if response.status == 204
+        {message: "Uninstall successful"}
+      else
+        {
+          status: response.status_line,
+          body: response.body
+        }
+      end
+
+    output_json(output.to_json)
+  end
+
   no_commands do
     def get_jira_host(git_hub_installation_id)
       data = JSON.parse(info_response(git_hub_installation_id))
@@ -105,7 +129,7 @@ class Client
     excon.request(expects: [200, 201], method: :get, path: path, query: query)
   end
 
-  def post(path, body)
+  def post(path, body = {})
     excon.post(
       path: path,
       body: URI.encode_www_form(body),

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -190,7 +190,7 @@ app.post('/:installationId/sync', bodyParser, async (req, res) => {
 })
 
 app.get('/jira/:clientKey', bodyParser, async (request, response) => {
-  const installation = await Installation.findOne({where: {clientKey: request.params.clientKey}})
+  const installation = await Installation.findOne({ where: { clientKey: request.params.clientKey } })
   const jiraClient = new JiraClient(installation)
   const subscriptionSummary = (subscription) => {
     return {
@@ -210,6 +210,26 @@ app.get('/jira/:clientKey', bodyParser, async (request, response) => {
   }
 
   response.json(data)
+})
+
+app.post('/jira/:clientKey/uninstall', bodyParser, async (request, response) => {
+  response.locals.installation = await Installation.findOne({ where: { clientKey: request.params.clientKey } })
+
+  if (response.locals.installation) {
+    const jiraClient = new JiraClient(response.locals.installation)
+    const checkAuthorization = request.body.force !== 'true'
+
+    if (checkAuthorization && jiraClient.isAuthorized()) {
+      response.status(400).json({ message: 'Refusing to uninstall authorized Jira installation' })
+    } else {
+      request.log.info(`Forcing uninstall for ${response.locals.installation.clientKey}`)
+
+      const uninstall = require('../jira/uninstall')
+      await uninstall(request, response)
+    }
+  } else {
+    response.sendStatus(404)
+  }
 })
 
 app.post('/jira/:installationId/verify', bodyParser, async (req, response) => {

--- a/lib/jira/uninstall.js
+++ b/lib/jira/uninstall.js
@@ -1,20 +1,16 @@
-const { Installation, Subscription } = require('../models')
+const { Subscription } = require('../models')
 
 module.exports = async (req, res) => {
   const { installation } = res.locals
   const subscriptions = await Subscription.getAllForHost(installation.jiraHost)
 
   if (subscriptions) {
-    await Promise.all(subscriptions.map(async subscription => {
-      return subscription.uninstall()
-    }))
+    await Promise.all(subscriptions.map(async subscription => subscription.uninstall()))
   }
 
-  req.log(`App uninstalled on Jira. Uninstalling id=${installation.id}.`)
+  await installation.uninstall()
 
-  await Installation.uninstall({
-    clientKey: req.body.clientKey
-  })
+  req.log(`App uninstalled on Jira. Uninstalling id=${installation.id}.`)
 
   return res.sendStatus(204)
 }

--- a/lib/models/installation.js
+++ b/lib/models/installation.js
@@ -105,12 +105,8 @@ module.exports = class Installation extends Sequelize.Model {
     return installation
   }
 
-  static async uninstall (payload) {
-    return Installation.destroy({
-      where: {
-        clientKey: getHashedKey(payload.clientKey)
-      }
-    })
+  async uninstall () {
+    this.destroy()
   }
 
   async subscriptions () {


### PR DESCRIPTION
We recently discovered a number of Jira installations that had lost the ability to authenticate to the Jira API. This renders them quite useless. Each time we process a webhook for one of these installations, an error is thrown.

A investigation found more than 150 such instances. While it’s not clear how they ended up in that state, it is likely prudent to clean them up. This commit adds the ability to do so using `bin/stafftools`.

```
$ bin/stafftools help jira-uninstall
Usage:
  stafftools jira-uninstall <client_key>

Options:
  [--force]                # Force uninstall for an authorized Jira installation
  [--token=TOKEN]          # Personal access token (defaults to GITHUB_TOKEN)
  [--host=HOST]            # Jira integration host (useful to test against staging or development)
                           # Default: https://jira.github.com
  [--debug], [--no-debug]  # Output full request and response (hepful when an error occurs)

Description:
  Trigger the same uninstall process that occurs when a customer uninstalls the GitHub for Jira Atlassian Marketplace app.

  Note: this does not uninstall the app from a customer's Jira instance, it only removes the data from our side.
```

To protect against accidentally uninstalling a working installation, the endpoint checks whether or not we can talk to the Jira instance. If we can, the uninstall is aborted. For cases where you still need to uninstall, run the command again with `--force`.