### PR TITLE
Wait for authorization check

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -219,7 +219,7 @@ app.post('/jira/:clientKey/uninstall', bodyParser, async (request, response) => 
     const jiraClient = new JiraClient(response.locals.installation)
     const checkAuthorization = request.body.force !== 'true'
 
-    if (checkAuthorization && jiraClient.isAuthorized()) {
+    if (checkAuthorization && await jiraClient.isAuthorized()) {
       response.status(400).json({ message: 'Refusing to uninstall authorized Jira installation' })
     } else {
       request.log.info(`Forcing uninstall for ${response.locals.installation.clientKey}`)


### PR DESCRIPTION
There is a safety in place to avoid accidentally uninstalling an authorized Jira installation.

```javascript
// $ bin/stafftools jira-uninstall 347a4493812968d2c7e674f4d220837b26a9b9b5c0eae709ea5a378ce179938f
{
  "status": "HTTP/1.1 400 Bad Request\r\n",
  "body": "{\"message\":\"Refusing to uninstall authorized Jira installation\"}"
}
```

However, a bug causes this warning to **always** occur.

When making the request to test the Jira API shared secret, we don’t `await` the promise. This causes `jiraClient.isAuthorized()` to return a promise, which evaluates as a truthy value.

To avoid this, let’s `await` the promise. This ensures the authorization request is run before we proceed with the if statement.