### PR TITLE
Ignore webhooks from known baddie

### DIFF
--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -22,6 +22,16 @@ const withSentry = function (callback) {
   }
 }
 
+const isFromIgnoredRepo = (payload) => {
+  // These point back to a repository for an installation that
+  // is generating an unusually high number of push events. This
+  // disables it temporarily. See https://github.com/github/integrations-jira-internal/issues/24.
+  //
+  // GitHub Apps install: https://admin.github.com/stafftools/users/seequent/installations/491520
+  // Repository: https://admin.github.com/stafftools/repositories/seequent/lf_github_testing
+  return payload.installation.id === 491520 && payload.repository.id === 205972230
+}
+
 module.exports = function middleware (callback) {
   return withSentry(async (context) => {
     context.sentry.setExtra('GitHub Payload', {
@@ -32,6 +42,10 @@ module.exports = function middleware (callback) {
     })
 
     if (context.payload.sender.type === 'Bot') {
+      return
+    }
+
+    if (isFromIgnoredRepo(context.payload)) {
       return
     }
 


### PR DESCRIPTION
There is a Jira installation with a repository that sees 100 push events per hour. Each push event contains 1,000 commits. Right now, this causes an enormous number of GitHub API requests, quickly resulting in rate limit errors.

To stop these errors and keep the Jira integration from wasting time processing these requests, I’ve hard coded the repo ID and ignored it.

**This is a temporary measure.** We’ll reach out to the customer and resolve it ASAP.