### PR TITLE
Add support section for referencing too many issue keys

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -54,7 +54,9 @@ This will rediscover all repositories in your installation and start a new sync.
 
 #### Referencing too many issues
 
-The Jira API only allows us to link 100 issues to a particular branch or commit. As a result, if we process any branch or commit message with over 100 issue keys, we only send the first 100 and show a warning message on the Sync status column. This warning does not affect the overall sync status for any other commits or branches referencing fewer than 100 issue keys in the installation.
+`Exceeded issue key reference limit. Some issues may not be linked.`
+
+This warning is shown when a branch or commit includes more than 100 issue keys. When a branch or commit exceeds this limit, we only send the first 100. This is enforced by Jira. This doesn't impact branches or commits that are under the limit or impact the sync status.
 
 Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -52,6 +52,10 @@ Because everyone's repository histories are different, it's difficult to determi
 
 This will rediscover all repositories in your installation and start a new sync.
 
+#### Referencing too many issues
+
+The Jira API only allows us to link 100 issues to a particular branch or commit. As a result, if we process any branch or commit message with over 100 issue keys, we only send the first 100 and show a warning message on the Sync status column. This warning does not affect the overall sync status for any other commits or branches referencing fewer than 100 issue keys in the installation.
+
 Still having trouble? [Contact GitHub Support for additional help](#getting-additional-help).
 
 ## Sync is STALLED


### PR DESCRIPTION
Add a small section about the warning message we show when we process a commit or branch that has more than 100 issue keys. This describes the behavior implemented in https://github.com/integrations/jira/pull/258#issuecomment-526606109

@ACyphus Not sure if we want to a picture or GIF of the actual warning message that is shown since there aren't any other images in the docs