### PR TITLE
Reduce page limit on branch query

### DIFF
--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -111,7 +111,7 @@ module.exports.processInstallation = (app, queues) => {
     }
 
     const execute = async () => {
-      for (const perPage of [50, 10, 5, 1]) {
+      for (const perPage of [20, 10, 5, 1]) {
         try {
           return await pagedProcessor(perPage)
         } catch (err) {

--- a/lib/sync/queries.js
+++ b/lib/sync/queries.js
@@ -86,7 +86,7 @@ module.exports = {
                   name
                 }
                 authoredDate
-                history(first: $per_page) {
+                history(first: 50) {
                   nodes {
                     message
                     oid

--- a/test/fixtures/api/graphql/commit-queries.js
+++ b/test/fixtures/api/graphql/commit-queries.js
@@ -2,7 +2,7 @@ const query = 'query ($owner: String!, $repo: String!, $per_page: Int!, $cursor:
 
 module.exports.commitsNoLastCursor = {
   query,
-  variables: { owner: 'integrations', repo: 'test-repo-name', per_page: 50, default_ref: 'master' }
+  variables: { owner: 'integrations', repo: 'test-repo-name', per_page: 20, default_ref: 'master' }
 }
 
 module.exports.commitsWithLastCursor = {
@@ -10,7 +10,7 @@ module.exports.commitsWithLastCursor = {
   variables: {
     owner: 'integrations',
     repo: 'test-repo-name',
-    per_page: 50,
+    per_page: 20,
     cursor: 'Y3Vyc29yOnYyOpK5MjAxsdlkwOC0yM1QxNzozODowNS0wNDowMM4MjT7J 99',
     default_ref: 'master'
   }

--- a/test/fixtures/api/graphql/pull-queries.js
+++ b/test/fixtures/api/graphql/pull-queries.js
@@ -2,7 +2,7 @@ const query = 'query ($owner: String!, $repo: String!, $per_page: Int!, $cursor:
 
 module.exports.pullsNoLastCursor = {
   query,
-  variables: { owner: 'integrations', repo: 'test-repo-name', per_page: 50 }
+  variables: { owner: 'integrations', repo: 'test-repo-name', per_page: 20 }
 }
 
 module.exports.pullsWithLastCursor = {
@@ -10,7 +10,7 @@ module.exports.pullsWithLastCursor = {
   variables: {
     owner: 'integrations',
     repo: 'test-repo-name',
-    per_page: 50,
+    per_page: 20,
     cursor: 'Y3Vyc29yOnYyOpK5MjAxOC0wOC0yM1QxNzozODowNS0wNDowMM4MjT7J'
   }
 }


### PR DESCRIPTION
Reduces the initial page size for the branch query to 20. We have a hunch that the subsequent page sizes do not actually get tried when the request times out since the page limit of 50 does not exceed the node limit ("MAX_NODE_LIMIT_EXCEEDED").

I'll follow up on this PR with more info about the error handling for smaller page sizes after I get a chance to debug later today / tomorrow.

https://github.com/integrations/jira/blob/3a6a26dd2c89d73a028cab7b710e88687ea5a020/lib/sync/installation.js#L114