### PR TITLE
Supercharge Octokit request errors

### DIFF
--- a/lib/frontend/github-client-middleware.js
+++ b/lib/frontend/github-client-middleware.js
@@ -20,7 +20,6 @@ module.exports = (getAppToken) => {
     })
 
     res.locals.client = appClient
-
     res.locals.isAdmin = isAdminFunction
 
     next()

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -1,6 +1,8 @@
 const Sentry = require('@sentry/node')
 
 const AxiosErrorEventDecorator = require('../models/axios-error-event-decorator')
+const OctokitError = require('../models/octokit-error')
+const SentryScopeProxy = require('../models/sentry-scope-proxy')
 const { Subscription } = require('../models')
 const getJiraClient = require('../jira/client')
 const getJiraUtil = require('../jira/util')
@@ -12,6 +14,7 @@ const withSentry = function (callback) {
   return async (context) => {
     context.sentry = new Sentry.Hub(Sentry.getCurrentHub().getClient())
     context.sentry.configureScope(scope => scope.addEventProcessor(AxiosErrorEventDecorator.decorate))
+    context.sentry.configureScope(scope => scope.addEventProcessor(SentryScopeProxy.processEvent))
 
     try {
       await callback(context)
@@ -34,6 +37,8 @@ const isFromIgnoredRepo = (payload) => {
 
 module.exports = function middleware (callback) {
   return withSentry(async (context) => {
+    OctokitError.wrapRequestErrors(context.github)
+
     context.sentry.setExtra('GitHub Payload', {
       event: context.name,
       action: context.payload.action,

--- a/lib/models/octokit-error.js
+++ b/lib/models/octokit-error.js
@@ -1,0 +1,78 @@
+const SentryScopeProxy = require('../models/sentry-scope-proxy')
+
+/*
+ * Wraps an Octokit HttpError and extracts metadata for Sentry.
+ *
+ * Intended to be used by `octokit.hook.wrap('request')`
+ */
+class OctokitError extends Error {
+  /*
+   * Takes an octokit instance and wraps request errors. Useful when the octokit is instantiated by someone else (i.e., Probot)
+   */
+  static wrapRequestErrors (octokit) {
+    octokit.hook.wrap('request', async (request, options) => {
+      try {
+        const response = await request(options)
+        return response
+      } catch (error) {
+        throw new OctokitError(error, options)
+      }
+    })
+  }
+
+  constructor (httpError, requestOptions) {
+    super(`${requestOptions.method} ${requestOptions.url} responded with ${httpError.code}`)
+
+    this.name = this.constructor.name
+    this.httpError = httpError
+    this.requestOptions = requestOptions
+
+    this.sentryScope = new SentryScopeProxy()
+    this.sentryScope.extra.request = this.requestMetadata()
+    this.sentryScope.extra.response = this.responseMetadata()
+    this.sentryScope.fingerprint = this.generateFingerprint()
+  }
+
+  get responseCode () {
+    return this.httpError.code
+  }
+
+  requestMetadata () {
+    return {
+      method: this.requestOptions.method,
+      path: this.requestOptions.url,
+      headers: this.requestOptions.headers
+    }
+  }
+
+  responseMetadata () {
+    return {
+      code: this.responseCode,
+      body: this.deserializeMessage(this.httpError.message),
+      headers: this.httpError.headers
+    }
+  }
+
+  generateFingerprint () {
+    return [
+      '{{ default }}',
+      this.requestOptions.method,
+      this.requestOptions.url,
+      this.responseCode
+    ]
+  }
+
+  deserializeMessage (message) {
+    try {
+      return JSON.parse(message)
+    } catch (error) {
+      if (error.name !== 'SyntaxError') {
+        throw error
+      }
+    }
+
+    return message
+  }
+}
+
+module.exports = OctokitError

--- a/lib/models/sentry-scope-proxy.js
+++ b/lib/models/sentry-scope-proxy.js
@@ -1,0 +1,40 @@
+/*
+ * Acts like a Sentry scope. See https://docs.sentry.io/enriching-error-data/scopes/?platform=node#configuring-the-scope
+ *
+ * Useful in contexts where a Sentry scope isn't available, like within the custom exception class.
+ * Use `SentryScopeProxy.processEvent` to propogate the error scope for thrown exceptions.
+ *
+ * Learn more at https://docs.sentry.io/platforms/node/#eventprocessors
+ */
+class SentryScopeProxy {
+  static processEvent (event, hint) {
+    if (hint.originalException.sentryScope) {
+      hint.originalException.sentryScope.addTo(event)
+    }
+
+    return event
+  }
+
+  constructor () {
+    this.extra = {}
+    this.fingerprint = null
+  }
+
+  setExtra (key, value) {
+    this.extra[key] = value
+  }
+
+  setFingerprint (fingerprint) {
+    this.fingerprint = fingerprint
+  }
+
+  addTo (event) {
+    Object.assign(event.extra, this.extra)
+
+    if (this.fingerprint) {
+      event.fingerprint = this.fingerprint
+    }
+  }
+}
+
+module.exports = SentryScopeProxy

--- a/lib/sync/discovery.js
+++ b/lib/sync/discovery.js
@@ -1,5 +1,6 @@
 const { Subscription } = require('../models')
 const { getRepositorySummary } = require('./jobs')
+const OctokitError = require('../models/octokit-error')
 
 const jobOpts = {
   removeOnComplete: true,
@@ -11,6 +12,8 @@ module.exports.discovery = (app, queues) => {
   return async function discoverContent (job) {
     const { jiraHost, installationId } = job.data
     const github = await app.auth(installationId)
+    OctokitError.wrapRequestErrors(github)
+
     const repositories = await github.paginate(github.apps.getInstallationRepositories({ per_page: 100 }), res => res.data.repositories)
     app.log(`${repositories.length} Repositories found for installationId=${installationId}`)
 

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -1,6 +1,7 @@
 const { Subscription } = require('../models')
 const getJiraClient = require('../jira/client')
 const { getRepositorySummary } = require('./jobs')
+const OctokitError = require('../models/octokit-error')
 
 const tasks = {
   pull: require('./pull-request').getPullRequests,
@@ -61,6 +62,7 @@ module.exports.processInstallation = (app, queues) => {
 
   async function getEnhancedGitHub (installationId) {
     const github = await app.auth(installationId)
+    OctokitError.wrapRequestErrors(github)
 
     // Record elapsed time for each GraphQL request
     github.hook.before('request', () => {

--- a/lib/transforms/push.js
+++ b/lib/transforms/push.js
@@ -3,6 +3,7 @@ const getJiraClient = require('../jira/client')
 const parseSmartCommit = require('./smart-commit')
 const reduceProjectKeys = require('../jira/util/reduce-project-keys')
 const { queues } = require('../worker')
+const OctokitError = require('../models/octokit-error')
 
 function mapFile (githubFile) {
   // changeType enum: [ "ADDED", "COPIED", "DELETED", "MODIFIED", "MOVED", "UNKNOWN" ]
@@ -88,6 +89,7 @@ function processPush (app) {
 
     const jiraClient = await getJiraClient(subscription.jiraHost, installationId, app.log)
     const github = await app.auth(installationId)
+    OctokitError.wrapRequestErrors(github)
 
     const commits = await Promise.all(
       shas.map(async sha => {

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -13,6 +13,7 @@ const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
 const { CONCURRENT_WORKERS = 1 } = process.env
 const { Subscription } = require('../models')
 const AxiosErrorEventDecorator = require('../models/axios-error-event-decorator')
+const SentryScopeProxy = require('../models/sentry-scope-proxy')
 
 // Setup queues
 const queues = {
@@ -53,6 +54,7 @@ const sentryMiddleware = function (jobHandler) {
   return async (job) => {
     job.sentry = new Sentry.Hub(Sentry.getCurrentHub().getClient())
     job.sentry.configureScope(scope => scope.addEventProcessor(AxiosErrorEventDecorator.decorate))
+    job.sentry.configureScope(scope => scope.addEventProcessor(SentryScopeProxy.processEvent))
 
     try {
       await jobHandler(job)

--- a/test/models/octokit-error.test.js
+++ b/test/models/octokit-error.test.js
@@ -1,0 +1,94 @@
+const OctokitError = require('../../lib/models/octokit-error')
+
+describe(OctokitError, () => {
+  const buildHttpError = ({ message, code, headers }) => {
+    const error = new Error(message)
+
+    error.code = code || 400
+    error.headers = headers || {}
+
+    return error
+  }
+
+  it('adds request metadata', () => {
+    const error = buildHttpError({ code: 403, message: 'ServerError' })
+    const requestOptions = {
+      headers: { accept: 'application/vnd.github.v3+json' },
+      method: 'GET',
+      url: '/users/:username'
+    }
+
+    const octokitError = new OctokitError(error, requestOptions)
+
+    expect(octokitError.sentryScope.extra.request).toEqual({
+      method: 'GET',
+      path: '/users/:username',
+      headers: { accept: 'application/vnd.github.v3+json' }
+    })
+  })
+
+  it('adds response metadata', () => {
+    const requestOptions = {}
+    const error = buildHttpError({
+      code: 403,
+      message: 'Server error',
+      headers: { 'x-github-request-id': 'E553:6597:B5C6C1:1623C44:5D7192D1' }
+    })
+
+    const octokitError = new OctokitError(error, requestOptions)
+
+    expect(octokitError.sentryScope.extra.response).toEqual({
+      code: 403,
+      body: 'Server error',
+      headers: { 'x-github-request-id': 'E553:6597:B5C6C1:1623C44:5D7192D1' }
+    })
+  })
+
+  it('deserializes JSON response body', () => {
+    const requestOptions = {}
+    const error = buildHttpError({
+      message: JSON.stringify({
+        message: 'API rate limit exceeded for installation ID 1339471.',
+        documentation_url: 'https://developer.github.com/v3/#rate-limiting'
+      })
+    })
+
+    const octokitError = new OctokitError(error, requestOptions)
+
+    expect(octokitError.sentryScope.extra.response.body).toEqual({
+      message: 'API rate limit exceeded for installation ID 1339471.',
+      documentation_url: 'https://developer.github.com/v3/#rate-limiting'
+    })
+  })
+
+  it('sets the message', () => {
+    const requestOptions = {
+      method: 'GET',
+      url: '/users/:username'
+    }
+    const error = buildHttpError({
+      code: 401,
+      message: JSON.stringify({
+        message: 'API rate limit exceeded for installation ID 1339471.',
+        documentation_url: 'https://developer.github.com/v3/#rate-limiting'
+      })
+    })
+
+    const octokitError = new OctokitError(error, requestOptions)
+    expect(octokitError.message).toEqual('GET /users/:username responded with 401')
+  })
+
+  it('sets fingerprint using method, path, and response code', () => {
+    const requestOptions = { method: 'GET', url: '/users/:username' }
+    const error = buildHttpError({ code: 401, message: 'Server error' })
+
+    const octokitError = new OctokitError(error, requestOptions)
+
+    expect(octokitError.sentryScope.fingerprint).toEqual([
+      '{{ default }}',
+      'GET',
+      '/users/:username',
+      401
+    ])
+  })
+})

--- a/test/models/sentry-scrope-proxy.test.js
+++ b/test/models/sentry-scrope-proxy.test.js
@@ -1,0 +1,83 @@
+const SentryScopeProxy = require('../../lib/models/sentry-scope-proxy')
+
+describe(SentryScopeProxy, () => {
+  describe('.processEvent', () => {
+    it('adds scope proxy to event', () => {
+      const scope = new SentryScopeProxy()
+      scope.setExtra('foo', { hi: 'hello' })
+
+      const event = { extra: {} }
+      const hint = {
+        originalException: {
+          sentryScope: scope
+        }
+      }
+
+      const returnedEvent = SentryScopeProxy.processEvent(event, hint)
+
+      expect(returnedEvent.extra).toEqual({ foo: { hi: 'hello' } })
+    })
+
+    it('does nothing with normal error', () => {
+      const event = { extra: {} }
+      const hint = { originalException: {} }
+
+      const returnedEvent = SentryScopeProxy.processEvent(event, hint)
+
+      expect(returnedEvent.extra).toEqual({})
+    })
+  })
+
+  describe('#setExtra', () => {
+    it('assigns key to value', () => {
+      const scope = new SentryScopeProxy()
+
+      scope.setExtra('blah', { hello: 'world' })
+
+      expect(scope.extra).toEqual({ blah: { hello: 'world' } })
+    })
+  })
+
+  describe('#setFingerprint', () => {
+    it('assigns key to value', () => {
+      const scope = new SentryScopeProxy()
+
+      scope.setFingerprint(['foo', 'bar'])
+
+      expect(scope.fingerprint).toEqual(['foo', 'bar'])
+    })
+  })
+
+  describe('#addTo', () => {
+    it('assigns extra and fingerprint to event', () => {
+      const event = { extra: {}, fingerprint: ['original'] }
+      const scope = new SentryScopeProxy()
+      scope.setExtra('data', { hello: 'world' })
+      scope.setFingerprint(['foo', 'bar'])
+
+      scope.addTo(event)
+
+      expect(event.extra).toEqual({ data: { hello: 'world' } })
+      expect(event.fingerprint).toEqual(['foo', 'bar'])
+    })
+
+    it('overrides value in extra', () => {
+      const event = { extra: { data: 'original value', other: 'something' } }
+      const scope = new SentryScopeProxy()
+      scope.setExtra('data', { hello: 'world' })
+
+      scope.addTo(event)
+
+      expect(event.extra).toEqual({ data: { hello: 'world' }, other: 'something' })
+    })
+
+    it("doesn't set fingerprint when not set", () => {
+      const event = { extra: {}, fingerprint: ['original'] }
+      const scope = new SentryScopeProxy()
+
+      scope.addTo(event)
+
+      expect(event.fingerprint).toEqual(['original'])
+    })
+  })
+})

--- a/test/unit/github/middleware.test.js
+++ b/test/unit/github/middleware.test.js
@@ -1,4 +1,5 @@
 const { logger } = require('probot/lib/logger')
+const Octokit = require('@octokit/rest')
 
 const { Installation, Subscription } = require('../../../lib/models')
 const middleware = require('../../../lib/github/middleware')
@@ -14,6 +15,7 @@ describe('Probot event middleware', () => {
           sender: { type: 'not bot' },
           installation: { id: 1234 }
         },
+        github: Octokit(),
         log: logger
       }
 


### PR DESCRIPTION
When a request from Octokit to the GitHub API fails, this wraps the error, adding additional context and ensuring the grouping is more meaningful.

```
HttpError: {“message":"API rate limit exceeded for installation ID 1339471.","documentation_url":"https://developer.github.com/v3/#rate-limiting"}
```

becomes

```
OctokitError: PATCH /repos/:owner/:repo/issues/:number responded with 403
```

The response from GitHub—`API rate limit exceeded…`—is available in full under the `response.body` metadata. The GitHub request ID can be found under `response.headers` metadata.

Errors are also now grouped by method, path, and response code. This should ensure better grouping in Sentry.