### PR TITLE
Add Datadog histogram for GitHub requests

### DIFF
--- a/lib/config/enhance-octokit.js
+++ b/lib/config/enhance-octokit.js
@@ -1,0 +1,29 @@
+const OctokitError = require('../models/octokit-error')
+const statsd = require('./statsd')
+
+const instrumentRequests = (octokit, log) => {
+  octokit.hook.wrap('request', async (request, options) => {
+    const requestStart = Date.now()
+    try {
+      const response = await request(options)
+      return response
+    } finally {
+      const elapsed = Date.now() - requestStart
+      statsd.histogram('github-request', elapsed, { path: options.url })
+      log.debug(`GitHub request time: ${elapsed}ms`)
+    }
+  })
+}
+
+/*
+ * Customize an Octokit instance behavior.
+ *
+ * This acts like an Octokit plugin but works on Octokit instances.
+ * (Because Probot instantiates the Octokit client for us, we can't use plugins.)
+ */
+module.exports = (octokit, log) => {
+  OctokitError.wrapRequestErrors(octokit)
+  instrumentRequests(octokit, log)
+
+  return octokit
+}

--- a/lib/config/statsd.js
+++ b/lib/config/statsd.js
@@ -2,6 +2,7 @@ const StatsD = require('hot-shots')
 
 module.exports = new StatsD({
   prefix: 'jira-integration.',
+  mock: process.env.NODE_ENV === 'test',
   globalTags: {
     env: process.env.NODE_ENV || 'unknown',
     dyno: process.env.DYNO || 'unknown'

--- a/lib/config/statsd.js
+++ b/lib/config/statsd.js
@@ -1,0 +1,9 @@
+const StatsD = require('hot-shots')
+
+module.exports = new StatsD({
+  prefix: 'jira-integration.',
+  globalTags: {
+    env: process.env.NODE_ENV || 'unknown',
+    dyno: process.env.DYNO || 'unknown'
+  }
+})

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -1,11 +1,11 @@
 const Sentry = require('@sentry/node')
 
 const AxiosErrorEventDecorator = require('../models/axios-error-event-decorator')
-const OctokitError = require('../models/octokit-error')
 const SentryScopeProxy = require('../models/sentry-scope-proxy')
 const { Subscription } = require('../models')
 const getJiraClient = require('../jira/client')
 const getJiraUtil = require('../jira/util')
+const enhanceOctokit = require('../config/enhance-octokit')
 
 // Returns an async function that reports errors errors to Sentry.
 // This works similar to Sentry.withScope but works in an async context.
@@ -37,7 +37,7 @@ const isFromIgnoredRepo = (payload) => {
 
 module.exports = function middleware (callback) {
   return withSentry(async (context) => {
-    OctokitError.wrapRequestErrors(context.github)
+    enhanceOctokit(context.github, context.log)
 
     context.sentry.setExtra('GitHub Payload', {
       event: context.name,

--- a/lib/sync/discovery.js
+++ b/lib/sync/discovery.js
@@ -1,6 +1,6 @@
 const { Subscription } = require('../models')
 const { getRepositorySummary } = require('./jobs')
-const OctokitError = require('../models/octokit-error')
+const enhanceOctokit = require('../config/enhance-octokit')
 
 const jobOpts = {
   removeOnComplete: true,
@@ -12,7 +12,7 @@ module.exports.discovery = (app, queues) => {
   return async function discoverContent (job) {
     const { jiraHost, installationId } = job.data
     const github = await app.auth(installationId)
-    OctokitError.wrapRequestErrors(github)
+    enhanceOctokit(github, app.log)
 
     const repositories = await github.paginate(github.apps.getInstallationRepositories({ per_page: 100 }), res => res.data.repositories)
     app.log(`${repositories.length} Repositories found for installationId=${installationId}`)

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -1,7 +1,7 @@
 const { Subscription } = require('../models')
 const getJiraClient = require('../jira/client')
 const { getRepositorySummary } = require('./jobs')
-const OctokitError = require('../models/octokit-error')
+const enhanceOctokit = require('../config/enhance-octokit')
 
 const tasks = {
   pull: require('./pull-request').getPullRequests,
@@ -62,17 +62,7 @@ module.exports.processInstallation = (app, queues) => {
 
   async function getEnhancedGitHub (installationId) {
     const github = await app.auth(installationId)
-    OctokitError.wrapRequestErrors(github)
-
-    // Record elapsed time for each GraphQL request
-    github.hook.before('request', () => {
-      github.timeStart = Date.now()
-    })
-
-    github.hook.after('request', () => {
-      const elapsed = Date.now() - github.timeStart
-      app.log.debug(`GitHub Request time for ${installationId}: (${elapsed}ms)`)
-    })
+    enhanceOctokit(github, app.log)
 
     return github
   }

--- a/lib/transforms/push.js
+++ b/lib/transforms/push.js
@@ -3,7 +3,7 @@ const getJiraClient = require('../jira/client')
 const parseSmartCommit = require('./smart-commit')
 const reduceProjectKeys = require('../jira/util/reduce-project-keys')
 const { queues } = require('../worker')
-const OctokitError = require('../models/octokit-error')
+const enhanceOctokit = require('../config/enhance-octokit')
 
 function mapFile (githubFile) {
   // changeType enum: [ "ADDED", "COPIED", "DELETED", "MODIFIED", "MOVED", "UNKNOWN" ]
@@ -89,7 +89,7 @@ function processPush (app) {
 
     const jiraClient = await getJiraClient(subscription.jiraHost, installationId, app.log)
     const github = await app.auth(installationId)
-    OctokitError.wrapRequestErrors(github)
+    enhanceOctokit(github, app.log)
 
     const commits = await Promise.all(
       shas.map(async sha => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1398,6 +1398,15 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
@@ -3609,6 +3618,12 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -4813,6 +4828,14 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
       "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+    },
+    "hot-shots": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-6.3.0.tgz",
+      "integrity": "sha512-9aSojxGXFDQG8EiRtUp7Cd/dG0vgiQ2E/dB/5B59rdEbV8++tqaa2v/OUJW7EYyplETaglnaXsjUA8DB3LFGrw==",
+      "requires": {
+        "unix-dgram": "2.0.x"
+      }
     },
     "hpkp": {
       "version": "2.0.0",
@@ -10422,6 +10445,24 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "unix-dgram": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.3.tgz",
+      "integrity": "sha512-Bay5CkSLcdypcBCsxvHEvaG3mftzT5FlUnRToPWEAVxwYI8NI/8zSJ/Gknlp86MPhV6hBA8I8TBsETj2tssoHQ==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "optional": true
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "express": "^4.16.3",
     "express-sslify": "^1.2.0",
     "helmet": "^3.13.0",
+    "hot-shots": "^6.3.0",
     "markdown": "^0.5.0",
     "moment": "^2.24.0",
     "moo": "^0.5.0",

--- a/script/datadog-spy
+++ b/script/datadog-spy
@@ -1,0 +1,7 @@
+#!/bin/bash
+# 
+# Run this script to spy on Datadog metrics locally.
+# 
+# This comes in handy when adding new metrics.
+# 
+nc -ucl 8125

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -1,3 +1,4 @@
 require('./env')
 require('./testdouble')
 require('./app')
+require('./matchers/to-have-sent-metrics')

--- a/test/setup/matchers/to-have-sent-metrics.js
+++ b/test/setup/matchers/to-have-sent-metrics.js
@@ -1,0 +1,113 @@
+/*
+
+This matcher makes it easier to write tests against Datadog metrics
+by providing the `toHaveSentMetrics` matcher.
+
+Examples:
+
+it('makes sure a metric of a certain type and name was sent', async () => {
+  await expect(async () => {
+    await someCode()
+  }).toHaveSentMetrics({
+    name: 'jira-integration.my-metric',
+    type: 'c', // c for count, h for histogram, etc
+  })
+})
+
+it('checks value', async () => {
+  await expect(async () => {
+    await someCode()
+  }).toHaveSentMetrics({
+    name: 'jira-integration.my-metric',
+    type: 'c',
+    value: 1 // incremented by 1
+  })
+})
+
+it('checks dynamic value', async () => {
+  await expect(async () => {
+    await someCode()
+  }).toHaveSentMetrics({
+    name: 'jira-integration.my-metric',
+    type: 'c',
+    value: (value) => value > 0 // make sure value is greater than 1
+  })
+})
+
+it('checks tags too', async () => {
+  await expect(async () => {
+    await someCode()
+  }).toHaveSentMetrics({
+    name: 'jira-integration.my-metric',
+    type: 'c',
+    tags: { code: 200 } // will ensure that `code:200` is present
+  })
+})
+
+*/
+const statsd = require('../../../lib/config/statsd')
+const diff = require('jest-diff')
+
+const parseStatsdMessage = (stastsdMessage) => {
+  const [metric, type, tagsString] = stastsdMessage.split('|')
+  const [name, value] = metric.split(':')
+  const tags = {}
+
+  tagsString.substring(1).split(',').map((tagString) => {
+    const [key, value] = tagString.split(':')
+    tags[key] = value
+  })
+
+  return {
+    name,
+    value: parseInt(value),
+    type,
+    tags
+  }
+}
+
+expect.extend({
+  async toHaveSentMetrics (testFunction, ...expectedMetrics) {
+    statsd.mockBuffer = []
+    await testFunction()
+    const actualMetrics = statsd.mockBuffer.map((message) => parseStatsdMessage(message))
+    const matchingMetrics = []
+
+    expectedMetrics.forEach((expectedMetric) => {
+      return actualMetrics.find((actualMetric) => {
+        const matchingName = actualMetric.name === expectedMetric.name
+        const matchingType = actualMetric.type === expectedMetric.type
+
+        let matchingValue = null
+        if (typeof expectedMetric.value === 'function') {
+          matchingValue = expectedMetric.value(actualMetric.value)
+        } else {
+          matchingValue = actualMetric.value === expectedMetric.value
+        }
+
+        if (matchingName && matchingType && matchingValue) {
+          let matchingTags = true
+          Object.entries(expectedMetric.tags).forEach(([name, expectedValue]) => {
+            if (actualMetric.tags[name] !== expectedValue) {
+              matchingTags = false
+            }
+          })
+
+          if (matchingTags) {
+            matchingMetrics.push(actualMetric)
+          }
+        }
+      })
+    })
+
+    const pass = matchingMetrics.length === expectedMetrics.length
+
+    return {
+      message: () => {
+        const diffString = diff(expectedMetrics, actualMetrics, { expand: true })
+        return this.utils.matcherHint('toHaveSentMetrics', 'function', 'metrics') + `\n\n${diffString}`
+      },
+      pass
+    }
+  }
+})

--- a/test/unit/config/enhance-octokit.test.js
+++ b/test/unit/config/enhance-octokit.test.js
@@ -1,0 +1,26 @@
+const Octokit = require('@octokit/rest')
+const nock = require('nock')
+
+const enhanceOctokit = require('../../../lib/config/enhance-octokit')
+
+describe(enhanceOctokit, () => {
+  describe('request metrics', () => {
+    it('sends reqest timing', async () => {
+      nock('https://api.github.com').get(/.+/).reply(200, [])
+
+      const log = { debug: () => {} }
+      const octokit = Octokit()
+
+      enhanceOctokit(octokit, log)
+
+      await expect(async () => {
+        await octokit.activity.listPublicEvents()
+      }).toHaveSentMetrics({
+        name: 'jira-integration.github-request',
+        type: 'h',
+        value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
+        tags: { path: '/events' }
+      })
+    })
+  })
+})


### PR DESCRIPTION
When a request is made to the GitHub API using Octokit, a timing histogram is sent to localhost:8125 over UDP. The value of the metric is the elapsed time of the request. Because we’re using a histogram, Datadog will turn this into six different metrics: `count`, `avg`, `median`, `95percentile`, `max`, `min`. For more information on Datadog histograms, see https://docs.datadoghq.com/developers/metrics/histograms/.

This metric will help us measure our interactions with the GitHub API to address timeout issues, monitor usage, and optimize GraphQL queries.

To test this out locally:

1. Start the server
2. In a new tab run `script/datadog-spy`
3. Trigger a sync

You should see metrics printed in the second tab.

Note: Because we don’t have a Datadog agent running on production, _these won't go anywhere yet._ That’s okay! This acts as the first step to adding meaning metrics.