### PR TITLE
Grab bag of small GitHub API metric improvements

### DIFF
--- a/lib/config/enhance-octokit.js
+++ b/lib/config/enhance-octokit.js
@@ -4,12 +4,26 @@ const statsd = require('./statsd')
 const instrumentRequests = (octokit, log) => {
   octokit.hook.wrap('request', async (request, options) => {
     const requestStart = Date.now()
+    let responseStatus = null
+
     try {
       const response = await request(options)
+      responseStatus = response.status
+
       return response
+    } catch (error) {
+      if (error.responseCode) {
+        responseStatus = error.responseCode
+      }
+
+      throw error
     } finally {
       const elapsed = Date.now() - requestStart
-      const tags = { path: options.url, method: options.method }
+      const tags = {
+        path: options.url,
+        method: options.method,
+        status: responseStatus
+      }
 
       statsd.histogram('github-request', elapsed, tags)
       log.debug(tags, `GitHub request time: ${elapsed}ms`)

--- a/lib/config/enhance-octokit.js
+++ b/lib/config/enhance-octokit.js
@@ -9,7 +9,7 @@ const instrumentRequests = (octokit, log) => {
       return response
     } finally {
       const elapsed = Date.now() - requestStart
-      statsd.histogram('github-request', elapsed, { path: options.url })
+      statsd.histogram('github-request', elapsed, { path: options.url, method: options.method })
       log.debug(`GitHub request time: ${elapsed}ms`)
     }
   })

--- a/lib/config/enhance-octokit.js
+++ b/lib/config/enhance-octokit.js
@@ -9,8 +9,10 @@ const instrumentRequests = (octokit, log) => {
       return response
     } finally {
       const elapsed = Date.now() - requestStart
-      statsd.histogram('github-request', elapsed, { path: options.url, method: options.method })
-      log.debug(`GitHub request time: ${elapsed}ms`)
+      const tags = { path: options.url, method: options.method }
+
+      statsd.histogram('github-request', elapsed, tags)
+      log.debug(tags, `GitHub request time: ${elapsed}ms`)
     }
   })
 }

--- a/lib/config/statsd.js
+++ b/lib/config/statsd.js
@@ -3,8 +3,5 @@ const StatsD = require('hot-shots')
 module.exports = new StatsD({
   prefix: 'jira-integration.',
   mock: process.env.NODE_ENV === 'test',
-  globalTags: {
-    env: process.env.NODE_ENV || 'unknown',
-    dyno: process.env.DYNO || 'unknown'
-  }
+  globalTags: { env: process.env.NODE_ENV || 'unknown' }
 })

--- a/test/setup/log-double.js
+++ b/test/setup/log-double.js
@@ -1,0 +1,35 @@
+/*
+ * Fills in for a logger, storing messages locally for easy assertions
+ *
+ * logger = new LogDouble()
+ * somethingThatLogs(logger)
+ * expect(logger.infoValues).toEqual([
+ *   { metadata: { foo: 'bar' }, message: 'Hello world' }
+ * ])
+ */
+class LogDouble {
+  constructor () {
+    this.debugValues = []
+    this.infoValues = []
+    this.warnValues = []
+    this.errorValues = []
+  }
+
+  debug (metadata, message) {
+    this.debugValues.push({ metadata, message })
+  }
+
+  info (metadata, message) {
+    this.infoValues.push({ metadata, message })
+  }
+
+  warn (metadata, message) {
+    this.warnValues.push({ metadata, message })
+  }
+
+  error (metadata, message) {
+    this.errorValues.push({ metadata, message })
+  }
+}
+
+module.exports = LogDouble

--- a/test/unit/config/enhance-octokit.test.js
+++ b/test/unit/config/enhance-octokit.test.js
@@ -1,25 +1,70 @@
 const Octokit = require('@octokit/rest')
 const nock = require('nock')
+const LogDouble = require('../../setup/log-double')
 
 const enhanceOctokit = require('../../../lib/config/enhance-octokit')
 
 describe(enhanceOctokit, () => {
   describe('request metrics', () => {
-    it('sends reqest timing', async () => {
-      nock('https://api.github.com').get(/.+/).reply(200, [])
+    let log
+    let octokit
 
-      const log = { debug: () => {} }
-      const octokit = Octokit()
+    beforeEach(() => {
+      log = new LogDouble()
+      octokit = Octokit()
+    })
 
-      enhanceOctokit(octokit, log)
+    describe('when successful', () => {
+      beforeEach(() => {
+        nock('https://api.github.com').get(/.+/).reply(200, [])
+        enhanceOctokit(octokit, log)
+      })
 
-      await expect(async () => {
+      it('sends reqest timing', async () => {
+        await expect(async () => {
+          await octokit.activity.listPublicEvents()
+        }).toHaveSentMetrics({
+          name: 'jira-integration.github-request',
+          type: 'h',
+          value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
+          tags: { path: '/events', method: 'GET' }
+        })
+      })
+
+      it('logs request timing', async () => {
         await octokit.activity.listPublicEvents()
-      }).toHaveSentMetrics({
-        name: 'jira-integration.github-request',
-        type: 'h',
-        value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
-        tags: { path: '/events', method: 'GET' }
+
+        const debugLog = log.debugValues[0]
+        expect(log.debugValues).toHaveLength(1)
+        expect(debugLog.metadata).toEqual({ path: '/events', method: 'GET' })
+        expect(debugLog.message).toMatch(/GitHub request time: \d+ms/)
+      })
+    })
+
+    describe('when fails', () => {
+      beforeEach(() => {
+        nock('https://api.github.com').get(/.+/).reply(500, [])
+        enhanceOctokit(octokit, log)
+      })
+
+      it('sends reqest timing', async () => {
+        await expect(async () => {
+          await octokit.activity.listPublicEvents().catch(() => { /* swallow error */ })
+        }).toHaveSentMetrics({
+          name: 'jira-integration.github-request',
+          type: 'h',
+          value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
+          tags: { path: '/events', method: 'GET' }
+        })
+      })
+
+      it('logs request timing', async () => {
+        await octokit.activity.listPublicEvents().catch(() => { /* swallow error */ })
+
+        const debugLog = log.debugValues[0]
+        expect(log.debugValues).toHaveLength(1)
+        expect(debugLog.metadata).toEqual({ path: '/events', method: 'GET' })
+        expect(debugLog.message).toMatch(/GitHub request time: \d+ms/)
       })
     })
   })

--- a/test/unit/config/enhance-octokit.test.js
+++ b/test/unit/config/enhance-octokit.test.js
@@ -19,7 +19,7 @@ describe(enhanceOctokit, () => {
         name: 'jira-integration.github-request',
         type: 'h',
         value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
-        tags: { path: '/events' }
+        tags: { path: '/events', method: 'GET' }
       })
     })
   })

--- a/test/unit/config/enhance-octokit.test.js
+++ b/test/unit/config/enhance-octokit.test.js
@@ -27,7 +27,7 @@ describe(enhanceOctokit, () => {
           name: 'jira-integration.github-request',
           type: 'h',
           value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
-          tags: { path: '/events', method: 'GET' }
+          tags: { path: '/events', method: 'GET', status: '200' }
         })
       })
 
@@ -36,7 +36,7 @@ describe(enhanceOctokit, () => {
 
         const debugLog = log.debugValues[0]
         expect(log.debugValues).toHaveLength(1)
-        expect(debugLog.metadata).toEqual({ path: '/events', method: 'GET' })
+        expect(debugLog.metadata).toEqual({ path: '/events', method: 'GET', status: 200 })
         expect(debugLog.message).toMatch(/GitHub request time: \d+ms/)
       })
     })
@@ -54,7 +54,7 @@ describe(enhanceOctokit, () => {
           name: 'jira-integration.github-request',
           type: 'h',
           value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
-          tags: { path: '/events', method: 'GET' }
+          tags: { path: '/events', method: 'GET', status: '500' }
         })
       })
 
@@ -63,7 +63,7 @@ describe(enhanceOctokit, () => {
 
         const debugLog = log.debugValues[0]
         expect(log.debugValues).toHaveLength(1)
-        expect(debugLog.metadata).toEqual({ path: '/events', method: 'GET' })
+        expect(debugLog.metadata).toEqual({ path: '/events', method: 'GET', status: 500 })
         expect(debugLog.message).toMatch(/GitHub request time: \d+ms/)
       })
     })


### PR DESCRIPTION
Four small things:

- Send `method` and `status` tags to Datadog (e.g., `method:GET` and  `status:200`)
- Add `method`, `path`, and `status` to log message (plus add tests)
- Remove unnecessary `dyno` global tag.

Some sample metrics:

```
github-request:647|h|#path:/installation/repositories,method:GET,status:200
github-request:704|h|#path:/graphql,method:POST,status:200
github-request:528|h|#path:/repos/_owner/_repo/issues/_number,method:PATCH,status:200
```

See commit messages for specifics.