### PR TITLE
Reduce cardinality of path tag

### DIFF
--- a/lib/config/enhance-octokit.js
+++ b/lib/config/enhance-octokit.js
@@ -1,5 +1,6 @@
 const OctokitError = require('../models/octokit-error')
 const statsd = require('./statsd')
+const { extractPath } = require('../jira/client/axios')
 
 const instrumentRequests = (octokit, log) => {
   octokit.hook.wrap('request', async (request, options) => {
@@ -20,7 +21,7 @@ const instrumentRequests = (octokit, log) => {
     } finally {
       const elapsed = Date.now() - requestStart
       const tags = {
-        path: options.url,
+        path: extractPath(options.url),
         method: options.method,
         status: responseStatus
       }

--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -106,11 +106,18 @@ const setRequestStartTime = (config) => {
   return config
 }
 
+const extractPath = (someUrl) => {
+  if (someUrl) {
+    const { pathname } = url.parse(someUrl)
+    return pathname
+  }
+}
+
 const instrumentRequest = (response) => {
   const requestDurationMs = Number(new Date() - response.config.requestStartTime)
   const tags = {
     method: response.config.method.toUpperCase(),
-    path: response.config.originalUrl,
+    path: extractPath(response.config.originalUrl),
     status: response.status
   }
 

--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -158,3 +158,5 @@ module.exports = (baseURL, secret, logger) => {
 
   return instance
 }
+
+module.exports.extractPath = extractPath

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -83,8 +83,12 @@ module.exports = async (jiraHost, gitHubInstallationId, logger) => {
     },
     devinfo: {
       branch: {
-        delete: (repositoryId, branchRef) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}/branch/${getJiraId(branchRef)}`, {
-          fields: { _updateSequenceId: Date.now() }
+        delete: (repositoryId, branchRef) => instance.delete(`/rest/devinfo/0.10/repository/:repositoryId/branch/:branchJiraId`, {
+          fields: {
+            _updateSequenceId: Date.now(),
+            repositoryId,
+            branchJiraId: getJiraId(branchRef)
+          }
         })
       },
       // Add methods for handling installationId properties that exist in Jira
@@ -100,14 +104,21 @@ module.exports = async (jiraHost, gitHubInstallationId, logger) => {
         undo: () => instance.post('/rest/devinfo/0.10/github/undoMigration', {})
       },
       pullRequest: {
-        delete: (repositoryId, number) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}/pull_request/${number}`, {
-          fields: { _updateSequenceId: Date.now() }
+        delete: (repositoryId, pullRequestId) => instance.delete(`/rest/devinfo/0.10/repository/:repositoryId/pull_request/:pullRequestId`, {
+          fields: {
+            _updateSequenceId: Date.now(),
+            repositoryId,
+            pullRequestId
+          }
         })
       },
       repository: {
-        get: (repositoryId) => instance.get(`/rest/devinfo/0.10/repository/${repositoryId}`),
-        delete: (repositoryId) => instance.delete(`/rest/devinfo/0.10/repository/${repositoryId}`, {
-          fields: { _updateSequenceId: Date.now() }
+        get: (repositoryId) => instance.get(`/rest/devinfo/0.10/repository/:repositoryId`, { fields: { repositoryId } }),
+        delete: (repositoryId) => instance.delete(`/rest/devinfo/0.10/repository/:repositoryId`, {
+          fields: {
+            _updateSequenceId: Date.now(),
+            repositoryId
+          }
         }),
         update: async (data, options) => {
           dedupIssueKeys(data)

--- a/test/setup/matchers/to-have-sent-metrics.js
+++ b/test/setup/matchers/to-have-sent-metrics.js
@@ -79,7 +79,9 @@ expect.extend({
         const matchingType = actualMetric.type === expectedMetric.type
 
         let matchingValue = null
-        if (typeof expectedMetric.value === 'function') {
+        if (!expectedMetric.hasOwnProperty('value')) {
+          matchingValue = true
+        } else if (typeof expectedMetric.value === 'function') {
           matchingValue = expectedMetric.value(actualMetric.value)
         } else {
           matchingValue = actualMetric.value === expectedMetric.value

--- a/test/unit/jira/client/axios.test.js
+++ b/test/unit/jira/client/axios.test.js
@@ -22,6 +22,20 @@ describe('Jira axios instance', () => {
           value: (value) => value > 0 && value < 20
         })
       })
+
+      it('removes URL query params from path', async () => {
+        nock(jiraHost).get('/foo/bar?baz=true').reply(200)
+
+        const jiraAxiosInstance = getJiraAxios(jiraHost, 'secret', new LogDouble())
+
+        await expect(async () => {
+          await jiraAxiosInstance.get('/foo/bar?baz=true')
+        }).toHaveSentMetrics({
+          name: 'jira-integration.jira_request',
+          type: 'h',
+          tags: { path: '/foo/bar' }
+        })
+      })
     })
 
     describe('when request fails', () => {


### PR DESCRIPTION
Yesterday, we connected production to Datadog and started seeing metrics! 🎉 Unfortunately, we quickly realized that there were far too many values being sent for the `path` tag. 😞 

![image](https://user-images.githubusercontent.com/300976/64806015-2a43ee00-d547-11e9-8464-6edd38d8104b.png)

To avoid this, I've modified the Jira Axios client to always use Express.js-like route parameters to interpolate user data into paths and to remove URL query parameters. This should reduce the total number of `path` values we send to Datadog and save us 💰.

✨ Props to @jules2689 for [warning of this problem](https://github.com/integrations/jira/pull/269#pullrequestreview-286245560) before it happened!