### PR TITLE
Swallow repo NOT_FOUND error during Initial Sync

### DIFF
--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -114,7 +114,7 @@ module.exports.processInstallation = (app, queues) => {
         try {
           return await pagedProcessor(perPage)
         } catch (err) {
-          processJobGitHubError(err)
+          handleGitHubError(err)
         }
       }
       throw new Error(`Error processing GraphQL query: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`)

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -103,13 +103,10 @@ module.exports.processInstallation = (app, queues) => {
     }
 
     const handleGitHubError = (err) => {
-      const ignoredErrors = [
-        'MAX_NODE_LIMIT_EXCEEDED',
-        'NOT_FOUND'
-      ]
-      const isIgnoredError = ignoredErrors.find(ignoredError => String(err).includes(ignoredError))
+      const ignoredErrorTypes = ['MAX_NODE_LIMIT_EXCEEDED']
+      const isIgnoredError = err.errors.filter(error => ignoredErrorTypes.includes(error.type)).length
 
-      if (isIgnoredError) {
+      if (!isIgnoredError) {
         throw (err)
       }
     }
@@ -174,6 +171,12 @@ module.exports.processInstallation = (app, queues) => {
         app.log(`Abuse detection triggered. Retrying in 60 seconds: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`)
         const { removeOnComplete, removeOnFail } = job.opts
         queues.installation.add(job.data, { delay: 60000, removeOnComplete, removeOnFail })
+        return
+      }
+      // Checks if parsed error type is NOT_FOUND: https://github.com/octokit/graphql.js/tree/master#errors
+      const isNotFoundError = err.errors.filter(error => error.type === 'NOT_FOUND').length
+      if (isNotFoundError) {
+        app.log(`Repository deleted after discovery, skipping initial sync: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`)
         return
       }
       throw err

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -104,9 +104,9 @@ module.exports.processInstallation = (app, queues) => {
 
     const handleGitHubError = (err) => {
       const ignoredErrorTypes = ['MAX_NODE_LIMIT_EXCEEDED']
-      const isIgnoredError = err.errors.filter(error => ignoredErrorTypes.includes(error.type)).length
+      const notIgnoredError = err.errors.filter(error => !ignoredErrorTypes.includes(error.type)).length
 
-      if (!isIgnoredError) {
+      if (notIgnoredError) {
         throw (err)
       }
     }

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -102,7 +102,7 @@ module.exports.processInstallation = (app, queues) => {
       return processor(github, repository, cursor, perPage)
     }
 
-    const processJobGitHubError = (err) => {
+    const handleGitHubError = (err) => {
       if (!String(err).includes('MAX_NODE_LIMIT_EXCEEDED') ||
           !String(err).includes('NOT_FOUND')) {
         throw (err)

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -176,7 +176,7 @@ module.exports.processInstallation = (app, queues) => {
       // Checks if parsed error type is NOT_FOUND: https://github.com/octokit/graphql.js/tree/master#errors
       const isNotFoundError = err.errors.filter(error => error.type === 'NOT_FOUND').length
       if (isNotFoundError) {
-        app.log(`Repository deleted after discovery, skipping initial sync: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`)
+        app.log.info(`Repository deleted after discovery, skipping initial sync: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`)
         return
       }
       throw err

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -103,8 +103,13 @@ module.exports.processInstallation = (app, queues) => {
     }
 
     const handleGitHubError = (err) => {
-      if (!String(err).includes('MAX_NODE_LIMIT_EXCEEDED') ||
-          !String(err).includes('NOT_FOUND')) {
+      const ignoredErrors = [
+        'MAX_NODE_LIMIT_EXCEEDED',
+        'NOT_FOUND'
+      ]
+      const isIgnoredError = ignoredErrors.find(ignoredError => String(err).includes(ignoredError))
+
+      if (isIgnoredError) {
         throw (err)
       }
     }

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -102,14 +102,19 @@ module.exports.processInstallation = (app, queues) => {
       return processor(github, repository, cursor, perPage)
     }
 
+    const processJobGitHubError = (err) => {
+      if (!String(err).includes('MAX_NODE_LIMIT_EXCEEDED') ||
+          !String(err).includes('NOT_FOUND')) {
+        throw (err)
+      }
+    }
+
     const execute = async () => {
       for (const perPage of [20, 10, 5, 1]) {
         try {
           return await pagedProcessor(perPage)
         } catch (err) {
-          if (!String(err).includes('MAX_NODE_LIMIT_EXCEEDED')) {
-            throw err
-          }
+          processJobGitHubError(err)
         }
       }
       throw new Error(`Error processing GraphQL query: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`)


### PR DESCRIPTION
**Problem:** If a user deletes a repo after starting a long-running sync the entire sync will fail.

**Context:** The repo sync state column is populated at the beginning of the sync in the discovery queue. If the sync runs over multiple days, a user can delete a repo that was initially in the sync state column. This causes the entire sync to fail since the sync job hits a `NOT_FOUND` error from GitHub when it tries to process that repo's sync state.

**Fix:** If the repo no longer exists, we should just be able to swallow the error and not fail the sync.