### PR TITLE
Follow up fix for NOT_FOUND during sync

### DIFF
--- a/lib/sync/commits.js
+++ b/lib/sync/commits.js
@@ -2,47 +2,42 @@ const transformCommit = require('../transforms/commit')
 const { getCommits: getCommitsQuery, getDefaultRef } = require('./queries')
 
 exports.getCommits = async (github, repository, cursor, perPage) => {
-  try {
-    const data = await github.query(getDefaultRef, {
-      owner: repository.owner.login,
-      repo: repository.name
-    })
+  const data = await github.query(getDefaultRef, {
+    owner: repository.owner.login,
+    repo: repository.name
+  })
 
-    const refName = (data.repository.defaultBranchRef) ? data.repository.defaultBranchRef.name : 'master'
+  const refName = (data.repository.defaultBranchRef) ? data.repository.defaultBranchRef.name : 'master'
 
-    const commitsData = await github.query(getCommitsQuery, {
-      owner: repository.owner.login,
-      repo: repository.name,
-      per_page: perPage,
-      cursor,
-      default_ref: refName
-    })
+  const commitsData = await github.query(getCommitsQuery, {
+    owner: repository.owner.login,
+    repo: repository.name,
+    per_page: perPage,
+    cursor,
+    default_ref: refName
+  })
 
-    // if the repository is empty, commitsData.repository.ref is null
-    const { edges } = commitsData.repository.ref
-      ? commitsData.repository.ref.target.history
-      : { edges: [] }
+  // if the repository is empty, commitsData.repository.ref is null
+  const { edges } = commitsData.repository.ref
+    ? commitsData.repository.ref.target.history
+    : { edges: [] }
 
-    const authors = edges.map(({ node: item }) => item.author)
-    const commits = edges.map(({ node: item }) => {
-      // translating the object into a schema that matches our transforms
-      return {
-        author: item.author,
-        authorTimestamp: item.authoredDate,
-        fileCount: 0,
-        sha: item.oid,
-        message: item.message,
-        url: item.url
-      }
-    })
+  const authors = edges.map(({ node: item }) => item.author)
+  const commits = edges.map(({ node: item }) => {
+    // translating the object into a schema that matches our transforms
+    return {
+      author: item.author,
+      authorTimestamp: item.authoredDate,
+      fileCount: 0,
+      sha: item.oid,
+      message: item.message,
+      url: item.url
+    }
+  })
 
-    const { data: jiraPayload } = transformCommit(
-      { commits, repository },
-      authors
-    )
-    return { edges, jiraPayload }
-  } catch (err) {
-    console.log(`Failed to get commit data for repository=${repository.name}`)
-    console.log(err)
-  }
+  const { data: jiraPayload } = transformCommit(
+    { commits, repository },
+    authors
+  )
+  return { edges, jiraPayload }
 }

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -174,9 +174,12 @@ module.exports.processInstallation = (app, queues) => {
         return
       }
       // Checks if parsed error type is NOT_FOUND: https://github.com/octokit/graphql.js/tree/master#errors
-      const isNotFoundError = err.errors.filter(error => error.type === 'NOT_FOUND').length
+      const isNotFoundError = err.errors && err.errors.filter(error => error.type === 'NOT_FOUND').length
       if (isNotFoundError) {
         app.log.info(`Repository deleted after discovery, skipping initial sync: installationId=${installationId}, repositoryId=${repositoryId}, task=${task}`)
+
+        const edgesLeft = [] // No edges left to process since the repository doesn't exist
+        await updateJobStatus(jiraClient, job, edgesLeft, task, repositoryId)
         return
       }
       throw err


### PR DESCRIPTION
Follow up fix for #274 

After triggering the sync for the customer that was experiencing this error I realized that `updateJobStatus` isn't called in the `catch` block so the next jobs weren't getting queued after swallowing the error.

This fix also led me to find that we were swallowing all errors for the `commit` sync task leading to the `NOT_FOUND` GraphQL error not being raised. This PR removes the `try` block that was added allowing us to catch the error when running the job in `installation.js`.

Ultimately, I think both of these errors could have been caught with stronger test coverage around the initial sync process as @jnraine and I have discussed. Will work on getting that in over the next few PRs.