### PR TITLE
Clean up failed and completed jobs on start

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -82,17 +82,21 @@ module.exports = {
     queues.discovery.process(5, sentryMiddleware(discovery(app, queues)))
     queues.installation.process(Number(CONCURRENT_WORKERS), sentryMiddleware(processInstallation(app, queues)))
     queues.push.process(Number(CONCURRENT_WORKERS), sentryMiddleware(limiterPerInstallation(processPush(app))))
+
     app.log(`Worker process started with ${CONCURRENT_WORKERS} CONCURRENT WORKERS`)
   },
 
   async clean () {
+    const gracePeriod = 10000
+    const limit = 50000
+
     return Promise.all([
-      queues.discovery.clean(10000, 'completed'),
-      queues.discovery.clean(10000, 'failed'),
-      queues.installation.clean(10000, 'completed'),
-      queues.installation.clean(10000, 'failed'),
-      queues.push.clean(10000, 'completed'),
-      queues.push.clean(10000, 'failed')
+      queues.discovery.clean(gracePeriod, 'completed', limit),
+      queues.discovery.clean(gracePeriod, 'failed', limit),
+      queues.installation.clean(gracePeriod, 'completed', limit),
+      queues.installation.clean(gracePeriod, 'failed', limit),
+      queues.push.clean(gracePeriod, 'completed', limit),
+      queues.push.clean(gracePeriod, 'failed', limit)
     ])
   },
 

--- a/test/unit/jira/client/axios.test.js
+++ b/test/unit/jira/client/axios.test.js
@@ -19,7 +19,7 @@ describe('Jira axios instance', () => {
           name: 'jira-integration.jira_request',
           type: 'h',
           tags: { path: '/foo/bar', method: 'GET', status: '200' },
-          value: (value) => value > 0 && value < 20
+          value: (value) => value > 0 && value < 50
         })
       })
 


### PR DESCRIPTION
The background job library we use doesn’t consistently remove completed jobs from Redis. On production, this led to unbounded memory growth.

While the [Bull reference guide] doesn’t specifically mention the need to manual clean old data, the library prov ides [`Queue#clean`]. Prior to this commit, we manually cleaned the queues by running `bin/clean-old-jobs`. ~To ensure we clean on a regular basis and to minimze chores, **old jobs are now cleaned on start up.**~ To decouple clean up from restarting the workers, old jobs will be cleaned up using the [Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler). (Hat tip: @jules2689)

Cleaning has also been limited to 50,000 jobs at a time. Doing too many at once can overload Redis. The specific number is a guess based on past experience: cleaning 500,000 jobs was too much for Redis.

[Bull reference guide]: https://optimalbits.github.io/bull/
[`Queue#clean`]: https://optimalbits.github.io/bull/