### PR TITLE
Send sync status metrics to Datadog

### DIFF
--- a/bin/send-sync-status-metrics
+++ b/bin/send-sync-status-metrics
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+require('dotenv').config()
+
+const Sentry = require('@sentry/node')
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
+  release: process.env.HEROKU_SLUG_COMMIT
+})
+
+const statsd = require('../lib/config/statsd')
+const { Subscription } = require('../lib/models')
+
+Subscription.syncStatusCounts().then((results) => {
+  results.forEach((row) => {
+    statsd.gauge('syncs', row.count, { status: row.syncStatus })
+  })
+
+  // Close client, triggering flush of metrics, then exit.
+  // (Without exit, process hangs. Without close, metric is never sent.)
+  statsd.close(() => {
+    process.exit()
+  })
+}).catch((error) => {
+  console.log('An error occurred while sending sync status metrics:', error)
+  Sentry.captureException(error)
+  process.exit(1)
+})

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -109,6 +109,16 @@ module.exports = class Subscription extends Sequelize.Model {
     return queues.installation.add({ installationId, jiraHost })
   }
 
+  /*
+   * Returns array with sync status counts. [ { syncStatus: 'COMPLETED', count: 123 }, ...]
+   */
+  static async syncStatusCounts () {
+    const syncStatusCountQuery = 'SELECT "syncStatus", COUNT(*) FROM "Subscriptions" GROUP BY "syncStatus"'
+    const [ results ] = await this.sequelize.query(syncStatusCountQuery)
+
+    return results
+  }
+
   async uninstall () {
     return this.destroy()
   }

--- a/test/unit/config/enhance-octokit.test.js
+++ b/test/unit/config/enhance-octokit.test.js
@@ -26,7 +26,7 @@ describe(enhanceOctokit, () => {
         }).toHaveSentMetrics({
           name: 'jira-integration.github-request',
           type: 'h',
-          value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
+          value: (value) => value > 0 && value < 50, // Value changes depending on how long nock takes
           tags: { path: '/events', method: 'GET', status: '200' }
         })
       })
@@ -53,7 +53,7 @@ describe(enhanceOctokit, () => {
         }).toHaveSentMetrics({
           name: 'jira-integration.github-request',
           type: 'h',
-          value: (value) => value > 0 && value < 20, // Value changes depending on how long nock takes
+          value: (value) => value > 0 && value < 50, // Value changes depending on how long nock takes
           tags: { path: '/events', method: 'GET', status: '500' }
         })
       })

--- a/test/unit/jira/client/axios.test.js
+++ b/test/unit/jira/client/axios.test.js
@@ -54,7 +54,7 @@ describe('Jira axios instance', () => {
           name: 'jira-integration.jira_request',
           type: 'h',
           tags: { path: '/foo/bar', method: 'GET', status: '500' },
-          value: (value) => value > 0 && value < 20
+          value: (value) => value > 0 && value < 50
         })
       })
     })


### PR DESCRIPTION
Every n minutes<sup>1</sup>, send over the count of sync statuses to Datdog. In other words, we want this query available as a Datadog metric:

```
psql> SELECT "syncStatus", COUNT(*) FROM "Subscriptions" GROUP BY "syncStatus";
 syncStatus | count
------------+-------
            | 5
 PENDING    | 1
 COMPLETE   | 100
 ACTIVE     | 10
 FAILED     | 5
(5 rows)
```

This adds `bin/send-sync-status-metrics` that runs the above query and sends it along to Datadog under the `jira_integration.syncs` metric.

```
jira_integration.syncs:5|g|#status:
jira_integration.syncs:1|g|#status:PENDING
jira_integration.syncs:100|g|#status:COMPLETE
jira_integration.syncs:10|g|#status:ACTIVE
jira_integration.syncs:5|g|#status:FAILED
```

This will allow us to track syncs over time and proactively track the health of syncs. My hope is that this can focus our attention on driving the total number of failed syncs to zero.

---

1: Once deployed, I plan to add a [Heroku scheduler](https://devcenter.heroku.com/articles/scheduler) job that sends the metrics every ten minutes. This is the most frequent interval possible with that add-on. I'm working to install the [Advanced Scheduler](https://elements.heroku.com/addons/advanced-scheduler) add-on, which will allow this metric to be collected every minute.