### PR TITLE
Extract `Sentry.init` into method and call that

### DIFF
--- a/bin/send-sync-status-metrics
+++ b/bin/send-sync-status-metrics
@@ -1,13 +1,9 @@
 #!/usr/bin/env node
 require('dotenv').config()
 
-const Sentry = require('@sentry/node')
+const { Sentry, initializeSentry } = require('../lib/config/sentry')
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
-  release: process.env.HEROKU_SLUG_COMMIT
-})
+initializeSentry()
 
 const statsd = require('../lib/config/statsd')
 const { Subscription } = require('../lib/models')

--- a/bin/worker
+++ b/bin/worker
@@ -5,13 +5,7 @@ if (process.env.NEWRELIC_KEY) {
   require('newrelic')
 }
 
-const Sentry = require('@sentry/node')
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
-  release: process.env.HEROKU_SLUG_COMMIT
-})
+require('../lib/config/sentry').initializeSentry()
 
 const worker = require('../lib/worker')
 

--- a/lib/config/sentry.js
+++ b/lib/config/sentry.js
@@ -1,0 +1,14 @@
+const Sentry = require('@sentry/node')
+
+const initializeSentry = () => {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
+    release: process.env.HEROKU_SLUG_COMMIT
+  })
+}
+
+module.exports = {
+  Sentry,
+  initializeSentry
+}

--- a/lib/run.js
+++ b/lib/run.js
@@ -5,13 +5,8 @@ require('dotenv').config()
 if (process.env.NEWRELIC_KEY) {
   require('newrelic') // eslint-disable-line global-require
 }
-const Sentry = require('@sentry/node')
 
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
-  release: process.env.HEROKU_SLUG_COMMIT
-})
+require('../lib/config/sentry').initializeSentry()
 
 const { findPrivateKey } = require('probot/lib/private-key')
 const { createProbot } = require('probot')


### PR DESCRIPTION
[Suggested by @zmoazeni], this ensures the know-how for initializing Sentry lives in one place. This makes it easy to modify how we initialize Sentry and will come in handy when it comes to add some global event handlers.

[Suggested by @zmoazeni]: https://github.com/integrations/jira/pull/279#discussion_r327363717