### PR TITLE
Instrument response only when present

### DIFF
--- a/lib/jira/client/axios.js
+++ b/lib/jira/client/axios.js
@@ -127,7 +127,12 @@ const instrumentRequest = (response) => {
 }
 
 const instrumentFailedRequest = (error) => {
-  instrumentRequest(error.response)
+  if (error.response) {
+    instrumentRequest(error.response)
+  } else {
+    console.log('Error during Axios request has no response property:', error)
+  }
+
   return Promise.reject(error)
 }
 


### PR DESCRIPTION
When an error is thrown while making a request with to the Jira API, there’s a good chance the error has a response attached to it. However, that’s not always the case.

Because the instrumentation relies on the response property, we now only call `instrumentRequest` when it is present.

This issue was raised because we saw a number of `Cannot read property 'config' of undefined` errors.

It’s not immediately obvious to me how to add an automated test to trigger this case. If you can think of one, please let me know.