### PR TITLE
Only mark sync as failed during sync

### DIFF
--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -81,7 +81,10 @@ module.exports.processInstallation = (app, queues) => {
     const github = await getEnhancedGitHub(installationId)
 
     const nextTask = getNextTask(subscription)
-    if (!nextTask) return
+    if (!nextTask) {
+      await subscription.update({ syncStatus: 'COMPLETE' })
+      return
+    }
 
     await subscription.update({ syncStatus: 'ACTIVE' })
 

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -182,6 +182,8 @@ module.exports.processInstallation = (app, queues) => {
         await updateJobStatus(jiraClient, job, edgesLeft, task, repositoryId)
         return
       }
+
+      await subscription.update({ syncStatus: 'FAILED' })
       throw err
     }
   }

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -11,7 +11,6 @@ const app = require('./app')
 
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
 const { CONCURRENT_WORKERS = 1 } = process.env
-const { Subscription } = require('../models')
 const AxiosErrorEventDecorator = require('../models/axios-error-event-decorator')
 const SentryScopeProxy = require('../models/sentry-scope-proxy')
 

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -43,9 +43,6 @@ Object.keys(queues).forEach(name => {
 
   queue.on('failed', async (job, err) => {
     app.log.error(`Error occurred while processing job id=${job.id} on queue name=${name}`)
-
-    const subscription = await Subscription.getSingleInstallation(job.data.jiraHost, job.data.installationId)
-    await subscription.update({ syncStatus: 'FAILED' })
   })
 })
 


### PR DESCRIPTION
Customers were reporting syncs switching from `COMPLETE` to `FAILED` without triggering a sync themselves. The underlying problem was with how and when we marked syncs as failed.
    
Syncs occur in the background on the `installation` queue.  When a sync background job throws an error, a global failure handler is called that updates `subscription.syncStatus` to `FAILED`. However, this global failure handler runs when _other_ jobs fail too.
    
This led to a sync being marked as `FAILED` when any job for that customer failed.
    
This commit avoids that by moving the `subscription.syncStatus` update out of the global failure handler and into the sync job.