### PR TITLE
Improve stafftools

### DIFF
--- a/bin/stafftools
+++ b/bin/stafftools
@@ -62,9 +62,9 @@ class JiraStaffTools < Thor
     output_json(response.body)
   end
 
-  desc "jira <client_key>", "Display installation for Jira instance"
-  def jira(client_key)
-    response = client.get("/api/jira/#{CGI.escape(client_key)}")
+  desc "jira <client_key_or_jira_host>", "Display installation for Jira instance"
+  def jira(client_key_or_jira_host)
+    response = client.get("/api/jira/#{CGI.escape(client_key_or_jira_host)}")
     output_json(response.body)
   end
 
@@ -90,6 +90,19 @@ class JiraStaffTools < Thor
       end
 
     output_json(output.to_json)
+  end
+
+  desc "resync_failed", "Resume most recently failed syncs"
+  option :limit, type: :numeric, default: 10, desc: "Number of failed subscriptions to resync"
+  option :offset, type: :numeric, default: 0, desc: "Useful to skip the first n failed syncs"
+  def resync_failed
+    response = client.post(
+      "/api/resyncFailed",
+      "limit" => options[:limit],
+      "offset" => options[:offset],
+    )
+
+    output_json(response.body)
   end
 
   no_commands do

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -4,10 +4,11 @@ const app = express()
 const bodyParser = require('body-parser').urlencoded({ extended: false })
 const octokit = require('@octokit/rest')()
 
-const { Installation } = require('../models')
+const { Installation, Subscription } = require('../models')
 const verifyInstallation = require('../jira/verify-installation')
 const logMiddleware = require('../middleware/log-middleware')
 const JiraClient = require('../models/jira-client')
+const { serializeSubscription, serializeJiraInstallation } = require('./serializers')
 
 async function getInstallation (client, subscription) {
   const id = subscription.gitHubInstallationId
@@ -114,7 +115,6 @@ app.get('/', (req, res) => {
 })
 
 app.get('/:installationId', async (req, res) => {
-  const { Subscription } = require('../models')
   const { installationId } = req.params
   const { client } = res.locals
   try {
@@ -153,7 +153,6 @@ app.get('/:installationId', async (req, res) => {
 })
 
 app.get('/:installationId/repoSyncState.json', async (req, res) => {
-  const { Subscription } = require('../models')
   const { installationId } = req.params
   const { jiraHost } = req.query
 
@@ -171,7 +170,6 @@ app.get('/:installationId/repoSyncState.json', async (req, res) => {
 })
 
 app.post('/:installationId/sync', bodyParser, async (req, res) => {
-  const { Subscription } = require('../models')
   const { installationId } = req.params
   req.log.info(req.body)
   const { jiraHost } = req.body
@@ -196,26 +194,27 @@ app.post('/:installationId/sync', bodyParser, async (req, res) => {
   }
 })
 
-const serializeSubscription = (subscription) => {
-  return {
-    gitHubInstallationId: subscription.gitHubInstallationId,
-    createdAt: subscription.createdAt,
-    updatedAt: subscription.updatedAt,
-    syncStatus: subscription.syncStatus
-  }
-}
+// Grab the last n failed syncs and trigger a sync
+app.post('/resyncFailed', bodyParser, async (request, response) => {
+  const maxLimit = 100
+  const defaultLimit = 10
+  const limit = Math.max(request.query.limit || defaultLimit, maxLimit)
+  const offset = request.query.offset || 0
 
-const serializeJiraInstallation = async (jiraInstallation, log) => {
-  const jiraClient = new JiraClient(jiraInstallation, log)
+  const failedSubscriptions = await Subscription.findAll(
+    {
+      where: { syncStatus: 'FAILED' },
+      limit: limit,
+      offset: offset,
+      order: [['updatedAt', 'DESC']]
+    }
+  )
 
-  return {
-    clientKey: jiraInstallation.clientKey,
-    host: jiraInstallation.jiraHost,
-    enabled: jiraInstallation.enabled,
-    authorized: (await jiraClient.isAuthorized()),
-    gitHubInstallations: (await jiraInstallation.subscriptions()).map((subscription) => serializeSubscription(subscription))
-  }
-}
+  await Promise.all(failedSubscriptions.map((subscription) => subscription.resumeSync()))
+
+  const data = failedSubscriptions.map((subscription) => serializeSubscription(subscription))
+  response.json(await Promise.all(data))
+})
 
 app.get('/jira/:clientKeyOrJiraHost', bodyParser, async (request, response) => {
   let jiraInstallations = []
@@ -281,7 +280,6 @@ app.post('/jira/:installationId/verify', bodyParser, async (req, response) => {
 })
 
 app.post('/:installationId/migrate/:undo?', bodyParser, async (req, res) => {
-  const { Subscription } = require('../models')
   const { installationId } = req.params
   const { jiraHost } = req.body
   const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -196,27 +196,42 @@ app.post('/:installationId/sync', bodyParser, async (req, res) => {
   }
 })
 
-app.get('/jira/:clientKey', bodyParser, async (request, response) => {
-  const installation = await Installation.findOne({ where: { clientKey: request.params.clientKey } })
-  const jiraClient = new JiraClient(installation, request.log)
-  const subscriptionSummary = (subscription) => {
-    return {
-      gitHubInstallationId: subscription.gitHubInstallationId,
-      createdAt: subscription.createdAt,
-      updatedAt: subscription.updatedAt,
-      syncStatus: subscription.syncStatus
-    }
+const serializeSubscription = (subscription) => {
+  return {
+    gitHubInstallationId: subscription.gitHubInstallationId,
+    createdAt: subscription.createdAt,
+    updatedAt: subscription.updatedAt,
+    syncStatus: subscription.syncStatus
   }
+}
 
-  const data = {
-    clientKey: installation.clientKey,
-    host: installation.jiraHost,
-    enabled: installation.enabled,
+const serializeJiraInstallation = async (jiraInstallation, log) => {
+  const jiraClient = new JiraClient(jiraInstallation, log)
+
+  return {
+    clientKey: jiraInstallation.clientKey,
+    host: jiraInstallation.jiraHost,
+    enabled: jiraInstallation.enabled,
     authorized: (await jiraClient.isAuthorized()),
-    gitHubInstallations: (await installation.subscriptions()).map((subscription) => subscriptionSummary(subscription))
+    gitHubInstallations: (await jiraInstallation.subscriptions()).map((subscription) => serializeSubscription(subscription))
+  }
+}
+
+app.get('/jira/:clientKeyOrJiraHost', bodyParser, async (request, response) => {
+  let jiraInstallations = []
+
+  if (request.params.clientKeyOrJiraHost.startsWith('http')) {
+    jiraInstallations = await Installation.findAll({ where: { jiraHost: request.params.clientKeyOrJiraHost } })
+  } else {
+    jiraInstallations = await Installation.findAll({ where: { clientKey: request.params.clientKeyOrJiraHost } })
   }
 
-  response.json(data)
+  if (jiraInstallations.length > 0) {
+    const data = jiraInstallations.map((jiraInstallation) => serializeJiraInstallation(jiraInstallation, request.log))
+    response.json(await Promise.all(data))
+  } else {
+    response.sendStatus(404)
+  }
 })
 
 app.post('/jira/:clientKey/uninstall', bodyParser, async (request, response) => {

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -115,6 +115,7 @@ app.get('/', (req, res) => {
 })
 
 app.get('/:installationId', async (req, res) => {
+  const { Subscription } = require('../models')
   const { installationId } = req.params
   const { client } = res.locals
   try {
@@ -153,6 +154,7 @@ app.get('/:installationId', async (req, res) => {
 })
 
 app.get('/:installationId/repoSyncState.json', async (req, res) => {
+  const { Subscription } = require('../models')
   const { installationId } = req.params
   const { jiraHost } = req.query
 
@@ -170,6 +172,7 @@ app.get('/:installationId/repoSyncState.json', async (req, res) => {
 })
 
 app.post('/:installationId/sync', bodyParser, async (req, res) => {
+  const { Subscription } = require('../models')
   const { installationId } = req.params
   req.log.info(req.body)
   const { jiraHost } = req.body
@@ -280,6 +283,7 @@ app.post('/jira/:installationId/verify', bodyParser, async (req, response) => {
 })
 
 app.post('/:installationId/migrate/:undo?', bodyParser, async (req, res) => {
+  const { Subscription } = require('../models')
   const { installationId } = req.params
   const { jiraHost } = req.body
   const subscription = await Subscription.getSingleInstallation(jiraHost, installationId)

--- a/lib/api/serializers.js
+++ b/lib/api/serializers.js
@@ -1,0 +1,28 @@
+const JiraClient = require('../models/jira-client')
+
+const serializeSubscription = (subscription) => {
+  return {
+    gitHubInstallationId: subscription.gitHubInstallationId,
+    jiraHost: subscription.jiraHost,
+    createdAt: subscription.createdAt,
+    updatedAt: subscription.updatedAt,
+    syncStatus: subscription.syncStatus
+  }
+}
+
+const serializeJiraInstallation = async (jiraInstallation, log) => {
+  const jiraClient = new JiraClient(jiraInstallation, log)
+
+  return {
+    clientKey: jiraInstallation.clientKey,
+    host: jiraInstallation.jiraHost,
+    enabled: jiraInstallation.enabled,
+    authorized: (await jiraClient.isAuthorized()),
+    gitHubInstallations: (await jiraInstallation.subscriptions()).map((subscription) => serializeSubscription(subscription))
+  }
+}
+
+module.exports = {
+  serializeSubscription,
+  serializeJiraInstallation
+}

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -123,6 +123,14 @@ module.exports = class Subscription extends Sequelize.Model {
     return this.destroy()
   }
 
+  async resumeSync () {
+    return Subscription.findOrStartSync(this)
+  }
+
+  async restartSync () {
+    return Subscription.findOrStartSync(this, 'full')
+  }
+
   // A stalled active sync is one that is ACTIVE but has not seen any updates in the last 15 minutes
   // This may happen when an error causes a sync to die without setting the status to 'FAILED'
   isActiveSyncStalled () {


### PR DESCRIPTION
This makes two improvements to the stafftools:

- Allow Jira installation lookups by host (https://github.com/integrations/jira/commit/608f62126b196c28efff51da2036e72b3870a795)
- Add ability to resume last `n` failed syncs (https://github.com/integrations/jira/commit/e3396027b1ef20893627f5d42ca884c35c95b10a)

See commits for full details.