### PR TITLE
Fix sync status metrics bug

### DIFF
--- a/bin/send-sync-status-metrics
+++ b/bin/send-sync-status-metrics
@@ -1,29 +1,10 @@
 #!/usr/bin/env node
 require('dotenv').config()
 
-const Sentry = require('@sentry/node')
-
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.SENTRY_ENV || process.env.NODE_ENV,
-  release: process.env.HEROKU_SLUG_COMMIT
-})
-
-const statsd = require('../lib/config/statsd')
-const { Subscription } = require('../lib/models')
-
-Subscription.syncStatusCounts().then((results) => {
-  results.forEach((row) => {
-    statsd.gauge('syncs', row.count, { status: row.syncStatus })
+const { queues } = require('../lib/worker')
+queues.metrics.add({})
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.log('An error occurred while enqueuing the metrics job:', error)
+    process.exit(1)
   })
-
-  // Close client, triggering flush of metrics, then exit.
-  // (Without exit, process hangs. Without close, metric is never sent.)
-  statsd.close(() => {
-    process.exit()
-  })
-}).catch((error) => {
-  console.log('An error occurred while sending sync status metrics:', error)
-  Sentry.captureException(error)
-  process.exit(1)
-})

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -4,6 +4,7 @@ const Sentry = require('@sentry/node')
 const { discovery } = require('../sync/discovery')
 const { processInstallation } = require('../sync/installation')
 const { processPush } = require('../transforms/push')
+const metricsJob = require('./metrics-job')
 
 const limiterPerInstallation = require('./limiter')
 
@@ -19,7 +20,8 @@ const SentryScopeProxy = require('../models/sentry-scope-proxy')
 const queues = {
   discovery: new Queue('Content discovery', REDIS_URL),
   installation: new Queue('Initial sync', REDIS_URL),
-  push: new Queue('Push transformation', REDIS_URL)
+  push: new Queue('Push transformation', REDIS_URL),
+  metrics: new Queue('Metrics', REDIS_URL)
 }
 
 // Setup error handling for queues
@@ -82,6 +84,7 @@ module.exports = {
     queues.discovery.process(5, sentryMiddleware(discovery(app, queues)))
     queues.installation.process(Number(CONCURRENT_WORKERS), sentryMiddleware(processInstallation(app, queues)))
     queues.push.process(Number(CONCURRENT_WORKERS), sentryMiddleware(limiterPerInstallation(processPush(app))))
+    queues.metrics.process(1, sentryMiddleware(metricsJob))
 
     app.log(`Worker process started with ${CONCURRENT_WORKERS} CONCURRENT WORKERS`)
   },

--- a/lib/worker/metrics-job.js
+++ b/lib/worker/metrics-job.js
@@ -1,0 +1,10 @@
+const statsd = require('../config/statsd')
+const { Subscription } = require('../../lib/models')
+
+module.exports = async (job) => {
+  const syncStatusCounts = await Subscription.syncStatusCounts()
+
+  syncStatusCounts.forEach((row) => {
+    statsd.gauge('syncs', row.count, { status: row.syncStatus })
+  })
+}


### PR DESCRIPTION
Added in #279, sync status metrics were intended to give greater insight into the overall health of the app. However, due to the way `bin/send-sync-status-metrics` was run using Heroku Scheduler, the metrics never made it to Datadog. [1]

This should remedy the problem by moving the metric sending into a background job. Because we already send metrics from background jobs to Datadog, I’m confident that the metrics will arrive. Heroku Scheduler still plays an important part but is now only repsonsible to enqueue the job.

Note: Bull (the background job library) supports what it calls [“repeated jobs”](https://github.com/OptimalBits/bull#repeated-jobs). However, I had difficulty getting these to work locally.

1: While I haven’t uncovered the cause, my hunch is that the Heroku kills the dyno before the Datadog agent sends the buffered metrics to Datadog.