### PR TITLE
Always throw when error types missing

### DIFF
--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -106,10 +106,14 @@ module.exports.processInstallation = (app, queues) => {
     }
 
     const handleGitHubError = (err) => {
-      const ignoredErrorTypes = ['MAX_NODE_LIMIT_EXCEEDED']
-      const notIgnoredError = err.errors.filter(error => !ignoredErrorTypes.includes(error.type)).length
+      if (err.errors) {
+        const ignoredErrorTypes = ['MAX_NODE_LIMIT_EXCEEDED']
+        const notIgnoredError = err.errors.filter(error => !ignoredErrorTypes.includes(error.type)).length
 
-      if (notIgnoredError) {
+        if (notIgnoredError) {
+          throw (err)
+        }
+      } else {
         throw (err)
       }
     }


### PR DESCRIPTION
There are certain GraphQL errors that we want to swallow, like `MAX_NODE_LIMIT_EXCEEDED`. However, sometimes the error object doesn’t contain a list of errors with types. In that case, we want to always throw the error.