### PR TITLE
Add support for unicode line separator to SmartCommitTokenizer

### DIFF
--- a/lib/smart-commit-tokenizer.js
+++ b/lib/smart-commit-tokenizer.js
@@ -10,6 +10,7 @@ module.exports = function () {
   const newline = {match: /\n/, lineBreaks: true, next: 'main'}
   const time = {match: /(?<= )#time(?= )/, push: 'workLog'}
   const whitespace = /[ \t]+/
+  const notWhitespace = /[^\r\n\t ]+/
 
   return moo.states({
     main: {
@@ -24,7 +25,7 @@ module.exports = function () {
     transition: {
       time,
       transition,
-      comment: /[^\r\n\t ]+/,
+      comment: notWhitespace,
       whitespace,
       carriageReturn,
       newline
@@ -36,7 +37,7 @@ module.exports = function () {
       hours: {match: /[\d.]+?h(?!\B)/, value: text => text.slice(0, -1)},
       minutes: {match: /[\d.]+?m(?!\B)/, value: text => text.slice(0, -1)},
       whitespace,
-      workLogComment: /.+/,
+      workLogComment: notWhitespace,
       carriageReturn,
       newline
     }

--- a/lib/smart-commit-tokenizer.js
+++ b/lib/smart-commit-tokenizer.js
@@ -9,8 +9,9 @@ module.exports = function () {
   const carriageReturn = {match: /\r/}
   const newline = {match: /\n/, lineBreaks: true, next: 'main'}
   const time = {match: /(?<= )#time(?= )/, push: 'workLog'}
-  const whitespace = /[ \t]+/
-  const notWhitespace = /[^\r\n\t ]+/
+  // Match whitespace characters except \r and \n, which are used to delimit commands
+  const whitespace = /[^\S\r\n]+/
+  const notWhitespace = /\S+/
 
   return moo.states({
     main: {
@@ -18,7 +19,8 @@ module.exports = function () {
       time,
       transition,
       whitespace,
-      ignoredText: /[^\r\n\t ]+?/,
+      // Non-greedy so `foo-JRA-123` extracts issue key JRA-123
+      ignoredText: /\S+?/,
       carriageReturn,
       newline
     },

--- a/test/unit/smart-commit-tokenizer.test.js
+++ b/test/unit/smart-commit-tokenizer.test.js
@@ -110,7 +110,7 @@ describe('SmartCommitTokenizer', () => {
       expect(valuesForType(tokens, 'days')).toEqual(['2'])
       expect(valuesForType(tokens, 'hours')).toEqual(['4'])
       expect(valuesForType(tokens, 'minutes')).toEqual(['30'])
-      expect(valuesForType(tokens, 'workLogComment')).toEqual(['Total work logged'])
+      expect(valuesForType(tokens, 'workLogComment')).toEqual(['Total', 'work', 'logged'])
     })
 
     it('extracts decimal times', () => {
@@ -125,7 +125,7 @@ describe('SmartCommitTokenizer', () => {
     it('only extracts comment from single line', () => {
       const tokens = tokenize('JRA-34 #time this is the comment\nthis is not')
 
-      expect(valuesForType(tokens, 'workLogComment')).toEqual(['this is the comment'])
+      expect(valuesForType(tokens, 'workLogComment')).toEqual(['this', 'is', 'the', 'comment'])
     })
   })
 
@@ -170,7 +170,7 @@ describe('SmartCommitTokenizer', () => {
       const tokens = tokenize(`WS-2 #time 1w almost done\nWS-3 #reopen`)
 
       expect(valuesForType(tokens, 'issueKey')).toEqual(['WS-2', 'WS-3'])
-      expect(valuesForType(tokens, 'workLogComment')).toEqual(['almost done'])
+      expect(valuesForType(tokens, 'workLogComment')).toEqual(['almost', 'done'])
       expect(valuesForType(tokens, 'transition')).toEqual(['reopen'])
     })
   })
@@ -186,6 +186,9 @@ describe('SmartCommitTokenizer', () => {
       tokenize(`there is an invisible unicode character here -> <-`) // eslint-disable-line no-irregular-whitespace
       tokenize(`😌 Emoji are totally 💯 fine ✨`)
       tokenize(`Rename Node#move to Node#move_within`)
+      /* eslint-disable */
+      tokenize(`JRA-123 #resolve do the thing to the code #time 3h `) // Ends with a unicode line separator
+      /* eslint-enable */
     })
   })
 })

--- a/test/unit/smart-commit-tokenizer.test.js
+++ b/test/unit/smart-commit-tokenizer.test.js
@@ -187,7 +187,15 @@ describe('SmartCommitTokenizer', () => {
       tokenize(`😌 Emoji are totally 💯 fine ✨`)
       tokenize(`Rename Node#move to Node#move_within`)
       /* eslint-disable */
-      tokenize(`JRA-123 #resolve do the thing to the code #time 3h `) // Ends with a unicode line separator
+      // Linter isn't happy about unicode whitespace characters
+      // This example ends with a unicode line separator
+      tokenize(`JRA-123 #resolve do the thing to the code #time 3h `)
+      // These examples includes every type of Unicode whitespace character
+      const allUnicodeWhitespaceCharacters = "foo bar foo bar foo bar foo᠎bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo​bar foo bar foo bar foo　bar foo﻿bar"
+      tokenize(`${allUnicodeWhitespaceCharacters}`)
+      tokenize(`JRA-123 #resolve ${allUnicodeWhitespaceCharacters} #time 3h`)
+      tokenize(`JRA-123 #resolve #time ${allUnicodeWhitespaceCharacters} 3h`)
+      tokenize(`JRA-123 #resolve #time 3h ${allUnicodeWhitespaceCharacters}`)
       /* eslint-enable */
     })
   })


### PR DESCRIPTION
A string ending with a [line separator], a whitespace unicode character (everyone’s favourite kind), would result in a syntax error.

This fixes that by matching tokenizing the `workLogComment` using a “not whitespace” regex pattern. This pattern matches any character that isn’t a carriage return, newline, tab, or space. You know, the normal whitespace stuff.

This results in the line separator being included as a work log comment but because we’re currently only extracting the issue keys from the tokenized smart commit, it will have no ill effect.

[line separator]: https://www.fileformat.info/info/unicode/char/2028/index.htm