### PR TITLE
Enable Node.js Language Metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "testdouble-nock": "^0.2.0"
   },
   "engines": {
-    "node": ">= 12.x"
+    "node": ">= 12.x < 13"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
We lost some nodejs metrics graphs, update the build packs and see if that re-enables them.
Fixes https://github.com/github/ecosystem-primitives/issues/485