### PR TITLE
Use Throng for Probot Concurrency

### DIFF
--- a/db/config.json
+++ b/db/config.json
@@ -19,6 +19,9 @@
     "ssl": true,
     "dialectOptions": {
       "ssl": true
+    },
+    "pool": {
+      "max": 5
     }
   }
 }

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 require('dotenv').config()
+const throng = require('throng')
 
 if (process.env.NEWRELIC_KEY) {
   require('newrelic') // eslint-disable-line global-require
@@ -12,6 +13,8 @@ const { findPrivateKey } = require('probot/lib/private-key')
 const { createProbot } = require('probot')
 const app = require('./configure-robot')
 
+const workers = process.env.WEB_CONCURRENCY || 1
+
 const probot = createProbot({
   id: process.env.APP_ID,
   secret: process.env.WEBHOOK_SECRET,
@@ -21,6 +24,15 @@ const probot = createProbot({
   webhookProxy: process.env.WEBHOOK_PROXY_URL
 })
 
-probot.load(app)
+/**
+ * Start the probot worker.
+ */
+function start () {
+  probot.load(app)
+  probot.start()
+}
 
-probot.start()
+throng({
+  workers,
+  lifetime: Infinity
+}, start)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11303,6 +11303,14 @@
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
+    "throng": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/throng/-/throng-4.0.0.tgz",
+      "integrity": "sha1-mDxroZk7WOroWZmKpof/6I34TBc=",
+      "requires": {
+        "lodash.defaults": "^4.0.1"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "request": "^2.88.0",
     "sequelize": "^4.44.3",
     "sequelize-cli": "^4.1.1",
-    "sequelize-encrypted": "^1.0.0"
+    "sequelize-encrypted": "^1.0.0",
+    "throng": "^4.0.0"
   },
   "devDependencies": {
     "@types/bull": "^3.3.19",


### PR DESCRIPTION
We sometimes have huge spikes in request queuing, we only have 5 workers, that may be part of the cause, let's use throng [like we did in slack](https://github.com/integrations/slack-private/pull/29) to add more workers on the same nodes to better utilize our resources.

## Env Vars

Heroku will calculate `WEB_CONCURRENCY` for us based on Dyno Ram Size / `WEB_MEMORY` == `WEB_CONCURRENCY`. We can also set it manually (which we will do at first to ensure a no-change rollout at first, see below).

## Preflight Checklist

- [x] Do we have enough redis connections available
- [x] Do we have enough postgres connections available -- **NO** Decrease Web worker autoscale to 5 max (see comment below)
- [x] Set the `WEB_CONCURRENCY` env var in heroku to `1` before deploying (this ensures we don't spin up more than 1 worker to start with)
- [x]  Set the `WEB_MEMORY` env var in heroku to 768 before deploying (this ensures that we have enough memory once we remove the `WEB_CONCURRENCY` variable.