### PR TITLE
Don't raise an exception if there's no jira client

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,5 +7,8 @@
   },
   "env": {
     "jest": true
+  },
+  "globals": {
+    "td": "writeable"
   }
 }

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -71,6 +71,11 @@ module.exports = function middleware (callback) {
       context.log = context.log.child({ gitHubInstallationId, jiraHost })
 
       const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, context.log)
+      if (jiraClient == null) {
+        // Don't call callback if we have no jiraClient
+        context.log.error(`No enabled installation found for ${jiraHost}.`)
+        return
+      }
       const util = getJiraUtil(jiraClient)
 
       try {

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -14,6 +14,9 @@ const ISSUE_KEY_API_LIMIT = 100
  */
 module.exports = async (jiraHost, gitHubInstallationId, logger) => {
   const installation = await Installation.getForHost(jiraHost)
+  if (installation == null) {
+    return
+  }
   const instance = getAxiosInstance(installation.jiraHost, installation.sharedSecret, logger)
 
   const client = {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "standard --fix",
     "es": "eslint",
     "start": "node ./lib/run.js",
-    "test": "jest --forceExit && standard",
+    "test": "standard && jest --forceExit",
     "test:watch": "jest --watch --notify --notifyMode=change",
     "worker": "node bin/worker"
   },

--- a/test/unit/jira/client/__snapshots__/index.test.js.snap
+++ b/test/unit/jira/client/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test getting a jira client Instllation exists 1`] = `
+exports[`Test getting a jira client Installation exists 1`] = `
 Object {
   "baseURL": "https://base-url.atlassian.net",
   "devinfo": Object {

--- a/test/unit/jira/client/__snapshots__/index.test.js.snap
+++ b/test/unit/jira/client/__snapshots__/index.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test getting a jira client Instllation exists 1`] = `
+Object {
+  "baseURL": "https://base-url.atlassian.net",
+  "devinfo": Object {
+    "branch": Object {
+      "delete": [Function],
+    },
+    "installation": Object {
+      "delete": [Function],
+      "exists": [Function],
+    },
+    "migration": Object {
+      "complete": [Function],
+      "undo": [Function],
+    },
+    "pullRequest": Object {
+      "delete": [Function],
+    },
+    "repository": Object {
+      "delete": [Function],
+      "get": [Function],
+      "update": [Function],
+    },
+  },
+  "issues": Object {
+    "comments": Object {
+      "addForIssue": [Function],
+      "getForIssue": [Function],
+    },
+    "get": [Function],
+    "getAll": [Function],
+    "parse": [Function],
+    "transitions": Object {
+      "getForIssue": [Function],
+      "updateForIssue": [Function],
+    },
+    "worklogs": Object {
+      "addForIssue": [Function],
+      "getForIssue": [Function],
+    },
+  },
+}
+`;

--- a/test/unit/jira/client/index.test.js
+++ b/test/unit/jira/client/index.test.js
@@ -13,7 +13,7 @@ describe('Test getting a jira client', () => {
     await installation.enable()
   })
 
-  test('Instllation exists', async () => {
+  test('Installation exists', async () => {
     const client = await getJiraClient(BASE_URL, 1, {})
     expect(client).toMatchSnapshot()
   })

--- a/test/unit/jira/client/index.test.js
+++ b/test/unit/jira/client/index.test.js
@@ -1,0 +1,32 @@
+const { Installation } = require('../../../../lib/models')
+const getJiraClient = require('../../../../lib/jira/client')
+
+const BASE_URL = 'https://base-url.atlassian.net'
+
+describe('Test getting a jira client', () => {
+  beforeEach(async () => {
+    const installation = await Installation.install({
+      host: BASE_URL,
+      sharedSecret: 'shared-secret',
+      clientKey: 'client-key'
+    })
+    await installation.enable()
+  })
+
+  test('Instllation exists', async () => {
+    const client = await getJiraClient(BASE_URL, 1, {})
+    expect(client).toMatchSnapshot()
+  })
+
+  test('Installation does not exist', async () => {
+    const installation = await Installation.findOne({
+      where: {
+        jiraHost: BASE_URL
+      }
+    })
+    await installation.disable()
+
+    const client = await getJiraClient(BASE_URL, 1, {})
+    expect(client).not.toBeDefined()
+  })
+})


### PR DESCRIPTION
Exceptions are expensive in nodejs (recovering, capturing the callback, submitting it to sentry, etc). We've seen this exception 55k times, and generally see it 1.1-1.3k times per day: https://sentry.io/organizations/github-integrations/issues/1201310569/events/013891d2c99b4797b1ba91139276cae8/

> Cannot read property 'jiraHost' of null

This is because if a user disables the integration, the `Installation.getForHost` function returns `null`, and then we try to use it anyways.

The simple solution is: If there isn't an installation, exit, we can't process it anyways, so no reason to raise an exception about it.

Since this is a configuration option (the user has configured the system to disable the plugin but also it still receives webhooks), I don't think that sending a metric is warranted, as the number of requests that we skipped due to users disabling the installation would not be actionable (as far as I can tell).