### PR TITLE
Use throng for multiple instances per dyno

### DIFF
--- a/bin/worker
+++ b/bin/worker
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 require('dotenv').config()
+const throng = require('throng')
 
 if (process.env.NEWRELIC_KEY) {
   require('newrelic')
@@ -8,5 +9,9 @@ if (process.env.NEWRELIC_KEY) {
 require('../lib/config/sentry').initializeSentry()
 
 const worker = require('../lib/worker')
+const throngWorkers = process.env.WEB_CONCURRENCY || 1
 
-worker.start()
+throng({
+  throngWorkers,
+  lifetime: Infinity
+}, worker.start)

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -31,7 +31,7 @@ Object.keys(queues).forEach(name => {
     app.log.info(`Job started name=${name} id=${job.id}`)
   })
 
-  queue.on('complete', function (job, jobPromise) {
+  queue.on('completed', function (job, jobPromise) {
     app.log.info(`Job completed name=${name} id=${job.id}`)
   })
 


### PR DESCRIPTION
This PR uses throng to spin up multiple bull workers per dyno. I'll try to explain the reasoning behind why this is a good idea in my opinion!

## Dyno Types

## 1x dyno ##

Previously (before Today) we were using the 1x dyno. The standard-1x has 512MB of ram, 1x cpu "Share", meaning other services from other companies can be running on our host, and cause resource contention. The sharing isn't perfect, and a really "noisy neighbor" can negatively impact the scheduler's ability to give us our fair share of resources.

Additionally, we've seen our CPU load jump to 30 today, along with large amounts of SWAP being used. All this points to us needing faster/dedicated hardware for our app.

## performance-m ##

The performance m is dedicated (it's all ours) and has 2.5GB of memory and we get all 11x of the compute. When I switched our workers to performance-m we suddenly saw our cpu load, disk, memory and more crash (in a good way). See the [datadog dashboard](https://app.datadoghq.com/dashboard/5sc-kmn-wiv/heroku-dynos?from_ts=1575922577850&live=false&tile_size=m&to_ts=1575936977850&tpl_var_heroku-pipeline=jira-integration-production) pinned to that time for more detail. This further validates the theory that larger nodes are better for us.

## Throng ##

So where does throng fit in here, I can hear you asking. I asked myself this question, and the answer is: for balance! Right now we have 2 variables for adjusting how we process messages off the queue:

1. \# of dynos, more dynos = more processing power
2. \# of Bull Queue workers, here we say "bull, you can use N workers in parallel". This is highly dependant on our workload, if most of our work is CPU bound (it's not, but some of it is) then this is bad, if it's all I/O bound (a lot of it is) then that's good! Node will only use 1 CPU for a process, this means that we have a lot of compute resources on our dedicated instance sitting idle.

So instead we spin up multiple copies each owning a CPU and sharing some of the RAM, this gives us a another variable to tune, so that we can be cost effective (less dynos) and resource effective (use all our resources on a dyno) and also not have to share resources (resource contention, memory, disk all can be problems!).