### PR TITLE
Specify # of workers instead of letting throng guess based on CPUs

### DIFF
--- a/bin/worker
+++ b/bin/worker
@@ -12,6 +12,6 @@ const worker = require('../lib/worker')
 const throngWorkers = process.env.WEB_CONCURRENCY || 1
 
 throng({
-  throngWorkers,
+  workers: throngWorkers,
   lifetime: Infinity
 }, worker.start)


### PR DESCRIPTION
Due to a poor variable naming choice, throng was set to the default for `workers`, which is based on the # of CPUs on the host, instead of our choice `WEB_CONCURRENCY`. This is fine in prod because we have a dedicated host, so the # of CPUs is limited to 5 (so we're not going crazy), but in staging we're using a 1x which is on a shared performance-L which has 46 CPUs which is a much different problem!