### PR TITLE
Update the subscriptions view

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @integrations/integrations-reviewers

--- a/db/migrations/20200206225834-update-views.js
+++ b/db/migrations/20200206225834-update-views.js
@@ -1,0 +1,30 @@
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+    create or replace view analytics.subscriptions(id, github_installation_id, jira_host, created_at, updated_at, repo_sync_state, selected_repositories, sync_status, sync_warning) as
+      SELECT "Subscriptions".id,
+            "Subscriptions"."gitHubInstallationId" AS github_installation_id,
+            "Subscriptions"."jiraHost"             AS jira_host,
+            "Subscriptions"."createdAt"            AS created_at,
+            "Subscriptions"."updatedAt"            AS updated_at,
+            "Subscriptions"."repoSyncState"        AS repo_sync_state,
+            "Subscriptions"."selectedRepositories" AS selected_repositories,
+            "Subscriptions"."syncStatus"           AS sync_status,
+            "Subscriptions"."syncWarning"          AS sync_warning
+      FROM "Subscriptions";
+    `)
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.sequelize.query(`
+    create or replace view analytics.subscriptions(id, github_installation_id, jira_host, created_at, updated_at, repo_sync_state) as
+      SELECT "Subscriptions".id,
+            "Subscriptions"."gitHubInstallationId" AS github_installation_id,
+            "Subscriptions"."jiraHost"             AS jira_host,
+            "Subscriptions"."createdAt"            AS created_at,
+            "Subscriptions"."updatedAt"            AS updated_at,
+            "Subscriptions"."repoSyncState"        AS repo_sync_state
+      FROM "Subscriptions";
+  `)
+  }
+}


### PR DESCRIPTION
The last time we added fields to the `Subscriptions` table we didn't update the view.

## What is the view used for?

Great question! I'd been wondering this too! Presto.githubapp.com, data.githubapp.com, looker.githubapp.com all use a mysql(ish?) syntax to query all the databases. When you query the Jira database from any of these sources, it connects to the jira read replica and issues a live query!

Now you're asking, why did you mention a "mysql(ish) syntax":

So, postgres is case sensitive, and that query language is decidedly *not*. To get around this, every postgres database that wants to be able to be queried by presto and its friends must create a `VIEW` that maps all the uppercase table names and columns to lower-snake-case.

## Why do we need this?

Another great question (wow you're full of great questions today, dear reader)! In order to be able to generate some looker dashboards with reporting metrics about sync states. Some of those question include (taken from https://github.com/github/integrations-jira-internal/issues/17)

*  How many repos per organization?
*  How many commits synced per organization?
*  How many commits synced per repository?

Looker is great for reporting, datadog is great for metrics/live current counts. A lot of our data in Jira is very sparse, so we have things like the cron job that calculates a bunch of counts from the database and submits them to Datadog. I think we could have a much better time with those sql queries as looker dashboards! (and we wouldn't need a code change to update them!)