### PR TITLE
Lock psql version in ci v10.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:10.12
         env:
           # The username of the actions runner that postgres defaults to
           POSTGRES_USER: runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:10
         env:
           # The username of the actions runner that postgres defaults to
           POSTGRES_USER: runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.12
+        image: postgres:10.11
         env:
           # The username of the actions runner that postgres defaults to
           POSTGRES_USER: runner


### PR DESCRIPTION
The latest version of psql v11 fails on the health check https://github.com/github/c2c-actions/issues/634

We're currently running psql v10.12 in production. 

* [Locking it to `postgres:10` fails](https://github.com/integrations/jira/actions/runs/49546049)
* [Locking it to `postgres:10.12` fails on the same thing](https://github.com/integrations/jira/actions/runs/49547136) (10 and 10.12 may be aliases)

Locking to `postgres:10.11` works for now.

I suspect we're going to need to ultimately tweak our healthcheck:

```
options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
```

But for now, I just want CI passing.