### PR TITLE
Add more new relic tracing

### DIFF
--- a/bin/worker
+++ b/bin/worker
@@ -2,10 +2,7 @@
 require('dotenv').config()
 const throng = require('throng')
 
-if (process.env.NEWRELIC_KEY) {
-  require('newrelic')
-}
-
+require('newrelic')
 require('../lib/config/sentry').initializeSentry()
 
 const worker = require('../lib/worker')

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -53,6 +53,7 @@ module.exports = function middleware (callback) {
     enhanceOctokit(context.github, context.log)
 
     if (newrelic !== undefined) {
+      newrelic.setControllerName(`github/events.${context.name}`)
       newrelic.addCustomAttributes({
         'Webhook ID': context.id,
         'Webhook Event': `${context.name}.${context.payload.action}`,

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -6,6 +6,12 @@ const { Subscription } = require('../models')
 const getJiraClient = require('../jira/client')
 const getJiraUtil = require('../jira/util')
 const enhanceOctokit = require('../config/enhance-octokit')
+
+let newrelic
+if (process.env.NEWRELIC_KEY) {
+  newrelic = require('newrelic')
+}
+
 // Returns an async function that reports errors errors to Sentry.
 // This works similar to Sentry.withScope but works in an async context.
 // A new Sentry hub is assigned to context.sentry and can be used later to add context to the error message.
@@ -37,6 +43,13 @@ const isFromIgnoredRepo = (payload) => {
 module.exports = function middleware (callback) {
   return withSentry(async (context) => {
     enhanceOctokit(context.github, context.log)
+
+    if (newrelic !== undefined) {
+      newrelic.addCustomAttributes({
+        'Webhook ID': context.id,
+        'Webhook Event': `${context.name}.${context.payload.action}`
+      })
+    }
 
     context.sentry.setExtra('GitHub Payload', {
       event: context.name,

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -80,7 +80,7 @@ module.exports = function middleware (callback) {
       return
     }
 
-    const subscriptions = await withNRSegment('middleware:Subscription.getAllForInstallation', async () => {
+    const subscriptions = await withNRSegment('Middleware: Subscription.getAllForInstallation', async () => {
       return Subscription.getAllForInstallation(gitHubInstallationId)
     })
 
@@ -99,7 +99,7 @@ module.exports = function middleware (callback) {
 
       context.log = context.log.child({ jiraHost })
 
-      const jiraClient = await withNRSegment('middleware:getJiraClient', async () => {
+      const jiraClient = await withNRSegment('Middleware: getJiraClient', async () => {
         return getJiraClient(jiraHost, gitHubInstallationId, context.log)
       })
       if (jiraClient == null) {
@@ -110,7 +110,7 @@ module.exports = function middleware (callback) {
       const util = getJiraUtil(jiraClient)
 
       try {
-        await withNRSegment('middleware:webhook handler', async () => callback(context, jiraClient, util))
+        await withNRSegment('Middleware: webhook handler', async () => callback(context, jiraClient, util))
       } catch (err) {
         context.sentry.captureException(err)
       }

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -47,7 +47,8 @@ module.exports = function middleware (callback) {
     if (newrelic !== undefined) {
       newrelic.addCustomAttributes({
         'Webhook ID': context.id,
-        'Webhook Event': `${context.name}.${context.payload.action}`
+        'Webhook Event': `${context.name}.${context.payload.action}`,
+        'Repository': context.payload.repository
       })
     }
 

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -6,11 +6,7 @@ const { Subscription } = require('../models')
 const getJiraClient = require('../jira/client')
 const getJiraUtil = require('../jira/util')
 const enhanceOctokit = require('../config/enhance-octokit')
-
-let newrelic
-if (process.env.NEWRELIC_KEY) {
-  newrelic = require('newrelic')
-}
+const newrelic = require('newrelic')
 
 // Returns an async function that reports errors errors to Sentry.
 // This works similar to Sentry.withScope but works in an async context.
@@ -30,14 +26,6 @@ const withSentry = function (callback) {
   }
 }
 
-function withNRSegment (segmentName, callback) {
-  if (newrelic !== undefined) {
-    return newrelic.startSegment(segmentName, true, callback)
-  } else {
-    return callback()
-  }
-}
-
 const isFromIgnoredRepo = (payload) => {
   // These point back to a repository for an installation that
   // is generating an unusually high number of push events. This
@@ -52,14 +40,12 @@ module.exports = function middleware (callback) {
   return withSentry(async (context) => {
     enhanceOctokit(context.github, context.log)
 
-    if (newrelic !== undefined) {
-      newrelic.setControllerName(`github/events.${context.name}`)
-      newrelic.addCustomAttributes({
-        'Webhook ID': context.id,
-        'Webhook Event': `${context.name}.${context.payload.action}`,
-        'Repository': context.payload.repository
-      })
-    }
+    newrelic.setControllerName(`github/events.${context.name}`)
+    newrelic.addCustomAttributes({
+      'Webhook ID': context.id,
+      'Webhook Event': `${context.name}.${context.payload.action}`,
+      'Repository': context.payload.repository
+    })
 
     context.sentry.setExtra('GitHub Payload', {
       event: context.name,
@@ -97,9 +83,7 @@ module.exports = function middleware (callback) {
 
       context.log = context.log.child({ jiraHost })
 
-      const jiraClient = await withNRSegment('Middleware: getJiraClient', async () => {
-        return getJiraClient(jiraHost, gitHubInstallationId, context.log)
-      })
+      const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, context.log)
       if (jiraClient == null) {
         // Don't call callback if we have no jiraClient
         context.log.error({ noop: 'no_jira_client' }, `No enabled installation found for ${jiraHost}.`)
@@ -108,7 +92,7 @@ module.exports = function middleware (callback) {
       const util = getJiraUtil(jiraClient)
 
       try {
-        await withNRSegment('Middleware: webhook handler', async () => callback(context, jiraClient, util))
+        await newrelic.startSegment('Middleware: webhook handler', true, async () => callback(context, jiraClient, util))
       } catch (err) {
         context.sentry.captureException(err)
       }

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -112,9 +112,7 @@ module.exports = function middleware (callback) {
       const util = getJiraUtil(jiraClient)
 
       try {
-        withNRSegment('middleware:webhook handler', async () => {
-          await callback(context, jiraClient, util)
-        })
+        await withNRSegment('middleware:webhook handler', async () => callback(context, jiraClient, util))
       } catch (err) {
         context.sentry.captureException(err)
       }

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -80,10 +80,7 @@ module.exports = function middleware (callback) {
       return
     }
 
-    const subscriptions = await withNRSegment('Middleware: Subscription.getAllForInstallation', async () => {
-      return Subscription.getAllForInstallation(gitHubInstallationId)
-    })
-
+    const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId)
     if (!subscriptions.length) {
       context.log({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found')
       return

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -60,13 +60,11 @@ module.exports = function middleware (callback) {
       })
     }
 
-    withNRSegment('middleware:sentry.setExtra', () => {
-      context.sentry.setExtra('GitHub Payload', {
-        event: context.name,
-        action: context.payload.action,
-        id: context.id,
-        repo: (context.payload.repository) ? context.repo() : undefined
-      })
+    context.sentry.setExtra('GitHub Payload', {
+      event: context.name,
+      action: context.payload.action,
+      id: context.id,
+      repo: (context.payload.repository) ? context.repo() : undefined
     })
 
     const gitHubInstallationId = context.payload.installation.id

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -30,6 +30,14 @@ const withSentry = function (callback) {
   }
 }
 
+function withNRSegment (segmentName, callback) {
+  if (newrelic !== undefined) {
+    return newrelic.startSegment(segmentName, true, callback)
+  } else {
+    return callback()
+  }
+}
+
 const isFromIgnoredRepo = (payload) => {
   // These point back to a repository for an installation that
   // is generating an unusually high number of push events. This
@@ -52,11 +60,13 @@ module.exports = function middleware (callback) {
       })
     }
 
-    context.sentry.setExtra('GitHub Payload', {
-      event: context.name,
-      action: context.payload.action,
-      id: context.id,
-      repo: (context.payload.repository) ? context.repo() : undefined
+    withNRSegment('middleware:sentry.setExtra', () => {
+      context.sentry.setExtra('GitHub Payload', {
+        event: context.name,
+        action: context.payload.action,
+        id: context.id,
+        repo: (context.payload.repository) ? context.repo() : undefined
+      })
     })
 
     const gitHubInstallationId = context.payload.installation.id
@@ -72,7 +82,10 @@ module.exports = function middleware (callback) {
       return
     }
 
-    const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId)
+    const subscriptions = await withNRSegment('middleware:Subscription.getAllForInstallation', async () => {
+      return Subscription.getAllForInstallation(gitHubInstallationId)
+    })
+
     if (!subscriptions.length) {
       context.log({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found')
       return
@@ -88,7 +101,9 @@ module.exports = function middleware (callback) {
 
       context.log = context.log.child({ jiraHost })
 
-      const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, context.log)
+      const jiraClient = await withNRSegment('middleware:getJiraClient', async () => {
+        return getJiraClient(jiraHost, gitHubInstallationId, context.log)
+      })
       if (jiraClient == null) {
         // Don't call callback if we have no jiraClient
         context.log.error({ noop: 'no_jira_client' }, `No enabled installation found for ${jiraHost}.`)
@@ -97,7 +112,9 @@ module.exports = function middleware (callback) {
       const util = getJiraUtil(jiraClient)
 
       try {
-        await callback(context, jiraClient, util)
+        withNRSegment('middleware:webhook handler', async () => {
+          await callback(context, jiraClient, util)
+        })
       } catch (err) {
         context.sentry.captureException(err)
       }

--- a/lib/jira/client/index.js
+++ b/lib/jira/client/index.js
@@ -1,6 +1,7 @@
 const { Installation, Subscription } = require('../../models')
 const getAxiosInstance = require('./axios')
 const { getJiraId } = require('../util/id')
+const newrelic = require('newrelic')
 
 // Max number of issue keys we can pass to the Jira API
 const ISSUE_KEY_API_LIMIT = 100
@@ -12,7 +13,7 @@ const ISSUE_KEY_API_LIMIT = 100
  * general, the client should match the Octokit rest.js design for clear
  * interoperability.
  */
-module.exports = async (jiraHost, gitHubInstallationId, logger) => {
+async function getJiraClient (jiraHost, gitHubInstallationId, logger) {
   const installation = await Installation.getForHost(jiraHost)
   if (installation == null) {
     return
@@ -140,6 +141,8 @@ module.exports = async (jiraHost, gitHubInstallationId, logger) => {
 
   return client
 }
+
+module.exports = async (...args) => newrelic.startSegment('lib/jira/client: getJiraClient', true, async () => getJiraClient(...args))
 
 /**
  * Splits commits in data payload into chunks of 400 and makes separate requests

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,10 +3,7 @@
 require('dotenv').config()
 const throng = require('throng')
 
-if (process.env.NEWRELIC_KEY) {
-  require('newrelic') // eslint-disable-line global-require
-}
-
+require('newrelic') // eslint-disable-line global-require
 require('../lib/config/sentry').initializeSentry()
 
 const { findPrivateKey } = require('probot/lib/private-key')

--- a/newrelic.js
+++ b/newrelic.js
@@ -9,11 +9,15 @@ exports.config = {
   /**
    * Array of application names.
    */
-  app_name: ['Jira Integration'],
+  app_name: [process.env.NEWRELIC_APP_NAME],
   /**
    * Your New Relic license key.
    */
   license_key: process.env.NEWRELIC_KEY,
+
+  // If the key exists, enable, otherwise disable
+  agent_enabled: !!process.env.NEWRELIC_KEY,
+
   logging: {
     /**
      * Level at which to log. 'trace' is most useful to New Relic when diagnosing


### PR DESCRIPTION
@tebriel I'm curious what you think about this approach. This is just adding more segments in newrelic so that our traces like https://rpm.newrelic.com/accounts/205/applications/154434972/transactions#id=5b225765625472616e73616374696f6e2f457870726573736a732f504f53542f2f222c22225d&app_trace_id=821171b1-6cf9-11ea-a8d9-0242ac110009_2716_4351 will have a lot more specific timing detail.

I ran this locally and verified the webhook handlers are working. I'm not using newrelic locally though so I'll test this in staging first.