### PR TITLE
Stop logging undefined actions

### DIFF
--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -42,7 +42,7 @@ module.exports = function middleware (callback) {
 
     newrelic.setControllerName(`github/events.${context.name}`)
     let webhookEvent = context.name
-    if (context.payload.action !== undefined) {
+    if (context.payload.action) {
       webhookEvent = `${webhookEvent}.${context.payload.action}`
     }
     newrelic.addCustomAttributes({

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -43,7 +43,7 @@ module.exports = function middleware (callback) {
     newrelic.setControllerName(`github/events.${context.name}`)
     let webhookEvent = context.name
     if (context.payload.action !== undefined) {
-      webhookEvent = `${webhookEvent}.context.payload.action`
+      webhookEvent = `${webhookEvent}.${context.payload.action}`
     }
     newrelic.addCustomAttributes({
       'Webhook ID': context.id,

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -41,9 +41,13 @@ module.exports = function middleware (callback) {
     enhanceOctokit(context.github, context.log)
 
     newrelic.setControllerName(`github/events.${context.name}`)
+    let webhookEvent = context.name
+    if (context.payload.action !== undefined) {
+      webhookEvent = `${webhookEvent}.context.payload.action`
+    }
     newrelic.addCustomAttributes({
       'Webhook ID': context.id,
-      'Webhook Event': `${context.name}.${context.payload.action}`,
+      'Webhook Event': webhookEvent,
       'Repository': context.payload.repository
     })
 


### PR DESCRIPTION
Some webhook events are printing like `push.undefined` which we don't need.

Others make sense like `pull_request.closed` so lets keep that