### PR TITLE
Adds ability for us to timeout webhook handlers

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -4,13 +4,14 @@ const middleware = require('./middleware')
 const pullRequest = require('./pull-request')
 const push = require('./push')
 const { createBranch, deleteBranch } = require('./branch')
+const webhookTimeout = require('../middleware/webhook-timeout')
 
 module.exports = (robot) => {
   robot.on('*', (context) => {
     context.log({ event: context.event, action: context.payload.action }, 'Event received')
   })
 
-  robot.on(['issue_comment.created', 'issue_comment.edited'], middleware(issueComment))
+  robot.on(['issue_comment.created', 'issue_comment.edited'], webhookTimeout(middleware(issueComment)))
 
   robot.on(['issues.opened', 'issues.edited'], middleware(issue))
 

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -79,18 +79,16 @@ module.exports = function middleware (callback) {
 
     context.sentry.setTag('transaction', `webhook:${context.name}.${context.payload.action}`)
     for (let subscription of subscriptions) {
-      if (context.timedout) {
-        // also send this to sentry
-        context.log.error({ timeout: true, timeoutElapsed: context.timedout }, `Timing out at after ${context.timedout}ms`)
-        return
-      }
       const jiraHost = subscription.jiraHost
-
       context.sentry.setTag('jiraHost', jiraHost)
       context.sentry.setTag('gitHubInstallationId', gitHubInstallationId)
       context.sentry.setUser({ jiraHost, gitHubInstallationId })
-
       context.log = context.log.child({ jiraHost })
+      if (context.timedout) {
+        Sentry.captureException(new Error('Timed out jira middleware iterating subscriptions'));
+        context.log.error({ timeout: true, timeoutElapsed: context.timedout }, `Timing out at after ${context.timedout}ms`)
+        return
+      }
 
       const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, context.log)
       if (jiraClient == null) {

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -85,7 +85,7 @@ module.exports = function middleware (callback) {
       context.sentry.setUser({ jiraHost, gitHubInstallationId })
       context.log = context.log.child({ jiraHost })
       if (context.timedout) {
-        Sentry.captureException(new Error('Timed out jira middleware iterating subscriptions'))
+        Sentry.captureMessage('Timed out jira middleware iterating subscriptions')
         context.log.error({ timeout: true, timeoutElapsed: context.timedout }, `Timing out at after ${context.timedout}ms`)
         return
       }

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -85,7 +85,7 @@ module.exports = function middleware (callback) {
       context.sentry.setUser({ jiraHost, gitHubInstallationId })
       context.log = context.log.child({ jiraHost })
       if (context.timedout) {
-        Sentry.captureException(new Error('Timed out jira middleware iterating subscriptions'));
+        Sentry.captureException(new Error('Timed out jira middleware iterating subscriptions'))
         context.log.error({ timeout: true, timeoutElapsed: context.timedout }, `Timing out at after ${context.timedout}ms`)
         return
       }

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -79,6 +79,11 @@ module.exports = function middleware (callback) {
 
     context.sentry.setTag('transaction', `webhook:${context.name}.${context.payload.action}`)
     for (let subscription of subscriptions) {
+      if (context.timedout) {
+        // also send this to sentry
+        context.log.error({ timeout: true, timeoutElapsed: context.timedout }, `Timing out at after ${context.timedout}ms`)
+        return
+      }
       const jiraHost = subscription.jiraHost
 
       context.sentry.setTag('jiraHost', jiraHost)

--- a/lib/middleware/webhook-timeout.js
+++ b/lib/middleware/webhook-timeout.js
@@ -1,0 +1,16 @@
+const TIMEOUT = Number(process.env.REQUEST_TIMEOUT_MS || 25000)
+
+module.exports = function webhookTimeout (callback) {
+  return async (context) => {
+    const timestamp = new Date()
+    const id = setTimeout(function () {
+      context.timedout = (new Date() - timestamp)
+    }, TIMEOUT)
+
+    try {
+      await callback(context)
+    } finally {
+      clearTimeout(id)
+    }
+  }
+}

--- a/lib/middleware/webhook-timeout.js
+++ b/lib/middleware/webhook-timeout.js
@@ -1,11 +1,11 @@
-const TIMEOUT = Number(process.env.REQUEST_TIMEOUT_MS || 25000)
+const DEFAULT_TIMEOUT = Number(process.env.REQUEST_TIMEOUT_MS || 25000)
 
-module.exports = function webhookTimeout (callback) {
+module.exports = function webhookTimeout (callback, timeout = DEFAULT_TIMEOUT) {
   return async (context) => {
     const timestamp = new Date()
     const id = setTimeout(function () {
       context.timedout = (new Date() - timestamp)
-    }, TIMEOUT)
+    }, timeout)
 
     try {
       await callback(context)

--- a/test/middleware/webhook-timeout.test.js
+++ b/test/middleware/webhook-timeout.test.js
@@ -1,7 +1,7 @@
 const webhookTimeout = require('../../lib/middleware/webhook-timeout')
 
 describe('Webhook Timeout', () => {
-  it('sets timedout context with seconds', async () => {
+  it('sets timedout context with milliseconds', async () => {
     const context = {}
     await webhookTimeout(async () => { await sleep(3) }, 1)(context)
     expect(context.timedout).toBeGreaterThan(0)

--- a/test/middleware/webhook-timeout.test.js
+++ b/test/middleware/webhook-timeout.test.js
@@ -1,0 +1,32 @@
+const webhookTimeout = require('../../lib/middleware/webhook-timeout')
+
+describe('Webhook Timeout', () => {
+  it('sets timedout context with seconds', async () => {
+    const context = {}
+    await webhookTimeout(async () => { await sleep(3) }, 1)(context)
+    expect(context.timedout).toBeGreaterThan(0)
+    expect(context.timedout).toBeLessThan(15)
+  })
+
+  it('clears timeout if successful', async () => {
+    const context = {}
+    await webhookTimeout(async () => { }, 1)(context)
+    await sleep(3)
+    expect(context.timedout).toBeUndefined()
+  })
+
+  it('clears timeout if error is thrown', async () => {
+    const context = {}
+    expect(
+      webhookTimeout(async () => { throw new Error('testing error') }, 1)(context)
+    ).rejects.toThrow('testing error')
+    await sleep(3)
+    expect(context.timedout).toBeUndefined()
+  })
+})
+
+function sleep (ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}


### PR DESCRIPTION
As far as I can tell, we can't kill the request from the outside, but instead we have to cooperatively kill from within the logic. Meaning we need to find and add checks like this wherever we have long running code.

This doesn't currently have any tests. I only tested it locally by adding:

```
    function sleep (ms) {
      return new Promise((resolve) => {
        setTimeout(resolve, ms)
      })
    }
    await sleep(5000)
```

And tweaking the `REQUEST_TIMEOUT_MS` in my .env