### PR TITLE
Change where we source all.js

### DIFF
--- a/lib/frontend/index.js
+++ b/lib/frontend/index.js
@@ -9,7 +9,7 @@ function secureHeaders (app, frontendApp) {
     directives: {
       defaultSrc: ["'none'"],
       // Allow <script> tags hosted by ourselves and from atlassian when inserted into an iframe
-      scriptSrc: ["'self'", process.env.APP_URL, 'https://*.atlassian.net', 'https://*.jira.com'],
+      scriptSrc: ["'self'", process.env.APP_URL, 'https://*.atlassian.net', 'https://*.jira.com', 'https://connect-cdn.atl-paas.net/'],
       // Allow XMLHttpRequest/fetch requests
       connectSrc: ["'self'", process.env.APP_URL],
       // Allow <style> tags hosted by ourselves as well as style="" attributes

--- a/views/jira-configuration.hbs
+++ b/views/jira-configuration.hbs
@@ -142,6 +142,7 @@
       </div>
       <script src="/public/js/jira-configuration.js"></script>
     </div>
-    <script src="{{host}}/atlassian-connect/all.js"></script>
+    <!-- Per https://blog.developer.atlassian.com/announcement-reminder-about-deprecation-of-xdm_e-usage-and-needing-to-load-all-js-from-the-cdn/ we are required to load this from this specific CDN -->
+    <script src="https://connect-cdn.atl-paas.net/all.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Per the [Atlassian Announcement](https://blog.developer.atlassian.com/announcement-reminder-about-deprecation-of-xdm_e-usage-and-needing-to-load-all-js-from-the-cdn/) we can no longer load all.js from the old location (`host/atlassian-connect/all.js`) (host is the integration base for your jira project i.e. https://github-integration.atlassian.net. And instead we must load it from https://connect-cdn.atl-paas.net/all.js. This PR changes this. I have verified that it fails to load in jira right now (https://github-integration.atlassian.net/plugins/servlet/ac/com.github.integration.production/github-post-install-page) and can re-validate after it's deployed.

Fixes https://github.com/github/ce-extensibility/issues/584