### PR TITLE
Sets originalException

### DIFF
--- a/lib/models/octokit-error.js
+++ b/lib/models/octokit-error.js
@@ -30,6 +30,7 @@ class OctokitError extends Error {
     this.sentryScope = new SentryScopeProxy()
     this.sentryScope.extra.request = this.requestMetadata()
     this.sentryScope.extra.response = this.responseMetadata()
+    this.sentryScope.extra.originalException = httpError
     this.sentryScope.fingerprint = this.generateFingerprint()
   }
 

--- a/test/models/octokit-error.test.js
+++ b/test/models/octokit-error.test.js
@@ -61,6 +61,19 @@ describe(OctokitError, () => {
     })
   })
 
+  it('adds original exception', () => {
+    const requestOptions = {}
+    const error = buildHttpError({
+      code: 403,
+      message: 'Server error',
+      headers: { 'x-github-request-id': 'E553:6597:B5C6C1:1623C44:5D7192D1' }
+    })
+
+    const octokitError = new OctokitError(error, requestOptions)
+
+    expect(octokitError.sentryScope.extra.originalException).toEqual(error)
+  })
+
   it('sets the message', () => {
     const requestOptions = {
       method: 'GET',


### PR DESCRIPTION
The hope here is that Sentry lists out both stack traces. I believe I've seen that before

The current issue is that sentry stack traces point to where we wrap the new OctokitError rather than where the error originated:

![:ref responded with 401 2020-04-07 16-09-30](https://user-images.githubusercontent.com/314/78714602-2bc17300-78ea-11ea-8e63-6a8964f1658b.png)


More information on Sentry hints: https://docs.sentry.io/platforms/node/

> originalException
>
>    The original exception that created the event. This is useful for changing how events are grouped, or to extract additional information.

I believe I've seen this before in Go-land. I think sentry will list both stack traces and this allows us to avoid munging any error's stack trace.

---

I should probably try this out locally and see it happen in Sentry but I feel comfortable enough yolo'ing this and checking the results in production.