### PR TITLE
Also clean metrics queue

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -105,7 +105,9 @@ module.exports = {
       queues.installation.clean(gracePeriod, 'completed', limit),
       queues.installation.clean(gracePeriod, 'failed', limit),
       queues.push.clean(gracePeriod, 'completed', limit),
-      queues.push.clean(gracePeriod, 'failed', limit)
+      queues.push.clean(gracePeriod, 'failed', limit),
+      queues.metrics.clean(gracePeriod, 'completed', limit),
+      queues.metrics.clean(gracePeriod, 'failed', limit)
     ])
   },
 
@@ -113,7 +115,8 @@ module.exports = {
     return Promise.all([
       queues.discovery.close(),
       queues.installation.close(),
-      queues.push.close()
+      queues.push.close(),
+      queues.metrics.close()
     ])
   }
 }


### PR DESCRIPTION
We have lots of keys regarding Metrics jobs, this should start purging them.

I'm still planning following up to use `removeOnComplete` separately https://github.com/OptimalBits/bull/issues/840 so this happens automatically