### PR TITLE
Remove jobs from redis by default

### DIFF
--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -22,12 +22,14 @@ function measureElapsedTime(startTime, tags) {
   statsd.histogram('job_duration', timeDiff, tags);
 }
 
+const queueOpts = { defaultJobOptions: { removeOnComplete: true } };
+
 // Setup queues
 const queues = {
-  discovery: new Queue('Content discovery', REDIS_URL),
-  installation: new Queue('Initial sync', REDIS_URL),
-  push: new Queue('Push transformation', REDIS_URL),
-  metrics: new Queue('Metrics', REDIS_URL),
+  discovery: new Queue('Content discovery', REDIS_URL, queueOpts),
+  installation: new Queue('Initial sync', REDIS_URL, queueOpts),
+  push: new Queue('Push transformation', REDIS_URL, queueOpts),
+  metrics: new Queue('Metrics', REDIS_URL, queueOpts),
 };
 
 // Setup error handling for queues


### PR DESCRIPTION
We no longer need to manually clean these jobs from redis.

I tested this out locally by verifying the keys were trimmed appropriately.

Before I deploy this I will drop the scheduled job in Heroku.

fixes: #280 