### PR TITLE
Move webhook handlers directly to bg job for pullRequest

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -17,8 +17,11 @@ module.exports = (robot) => {
 
   robot.on('push', middleware(push));
 
-  // robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited'], middleware(pullRequest));
-  robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited'], workerMiddleware('pullRequest'));
+  if (process.env.NO_BACKGROUND_WEBHOOKS === 'true') {
+    robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited'], middleware(pullRequest));
+  } else {
+    robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited'], workerMiddleware('pullRequest'));
+  }
 
   robot.on('create', middleware(createBranch));
   robot.on('delete', middleware(deleteBranch));

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -1,6 +1,6 @@
 const issueComment = require('./issue-comment');
 const issue = require('./issue');
-const middleware = require('./middleware');
+const { middleware, workerMiddleware } = require('./middleware');
 const pullRequest = require('./pull-request');
 const push = require('./push');
 const { createBranch, deleteBranch } = require('./branch');
@@ -17,7 +17,8 @@ module.exports = (robot) => {
 
   robot.on('push', middleware(push));
 
-  robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited'], middleware(pullRequest));
+  // robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited'], middleware(pullRequest));
+  robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited'], workerMiddleware('pullRequest'));
 
   robot.on('create', middleware(createBranch));
   robot.on('delete', middleware(deleteBranch));

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -135,18 +135,18 @@ function workerMiddleware(callbackName) {
     context.log = context.log.child({ gitHubInstallationId });
 
     if (context.payload.sender.type === 'Bot') {
-      context.log({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting futher execution since the sender is a bot');
+      context.log.info({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting futher execution since the sender is a bot');
       return;
     }
 
     if (isFromIgnoredRepo(context.payload)) {
-      context.log({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting futher execution since the repository is explicilty ignored');
+      context.log.info({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting futher execution since the repository is explicilty ignored');
       return;
     }
 
     const count = await Subscription.count({ where: { gitHubInstallationId } });
     if (count < 1) {
-      context.log({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');
+      context.log.info({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');
       return;
     }
 

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -7,6 +7,7 @@ const getJiraClient = require('../jira/client');
 const getJiraUtil = require('../jira/util');
 const enhanceOctokit = require('../config/enhance-octokit');
 const newrelic = require('newrelic');
+const { queues } = require('../worker');
 
 // Returns an async function that reports errors errors to Sentry.
 // This works similar to Sentry.withScope but works in an async context.
@@ -36,7 +37,7 @@ const isFromIgnoredRepo = (payload) =>
   payload.installation.id === 491520 && payload.repository.id === 205972230;
 
 
-module.exports = function middleware(callback) {
+function middleware(callback) {
   return withSentry(async (context) => {
     enhanceOctokit(context.github, context.log);
 
@@ -105,4 +106,56 @@ module.exports = function middleware(callback) {
       }
     }
   });
+}
+
+
+function workerMiddleware(callbackName) {
+  return withSentry(async (context) => {
+    enhanceOctokit(context.github, context.log);
+
+    newrelic.setControllerName(`github/events.${context.name}`);
+    let webhookEvent = context.name;
+    if (context.payload.action) {
+      webhookEvent = `${webhookEvent}.${context.payload.action}`;
+    }
+    newrelic.addCustomAttributes({
+      'Webhook ID': context.id,
+      'Webhook Event': webhookEvent,
+      Repository: context.payload.repository,
+    });
+
+    context.sentry.setExtra('GitHub Payload', {
+      event: context.name,
+      action: context.payload.action,
+      id: context.id,
+      repo: (context.payload.repository) ? context.repo() : undefined,
+    });
+
+    const gitHubInstallationId = context.payload.installation.id;
+    context.log = context.log.child({ gitHubInstallationId });
+
+    if (context.payload.sender.type === 'Bot') {
+      context.log({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting futher execution since the sender is a bot');
+      return;
+    }
+
+    if (isFromIgnoredRepo(context.payload)) {
+      context.log({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting futher execution since the repository is explicilty ignored');
+      return;
+    }
+
+    // TODO just check the count. Don't fetch all of them.
+    const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId);
+    if (!subscriptions.length) {
+      context.log({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');
+      return;
+    }
+
+    await queues.webhook.add({ callbackName, context });
+  });
+}
+
+module.exports = {
+  middleware,
+  workerMiddleware,
 };

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -144,9 +144,8 @@ function workerMiddleware(callbackName) {
       return;
     }
 
-    // TODO just check the count. Don't fetch all of them.
-    const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId);
-    if (!subscriptions.length) {
+    const count = await Subscription.count({ where: { gitHubInstallationId } });
+    if (count < 1) {
       context.log({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');
       return;
     }

--- a/lib/sync/webhook.js
+++ b/lib/sync/webhook.js
@@ -56,7 +56,14 @@ module.exports = (app, queues) => async function (job) {
     }
     const util = getJiraUtil(jiraClient);
 
-    const callback = pullRequest;
+    const callbacks = {
+      pullRequest,
+    };
+
+    const callback = callbacks[callbackName];
+    if (!callback) {
+      throw new Error(`Unknown callback: ${callbackName}. Known callbacks: ${Object.keys(callbacks)}`);
+    }
 
     try {
       await newrelic.startSegment('webhook handler', true, async () => callback(context, jiraClient, util));

--- a/lib/sync/webhook.js
+++ b/lib/sync/webhook.js
@@ -5,11 +5,6 @@ const getJiraUtil = require('../jira/util');
 const newrelic = require('newrelic');
 const pullRequest = require('../github/pull-request');
 
-const jobOpts = {
-  removeOnFail: true,
-  attempts: 3,
-};
-
 module.exports = (app, queues) => async function (job) {
   const { callbackName, context } = job.data;
   const gitHubInstallationId = context.payload.installation.id;

--- a/lib/sync/webhook.js
+++ b/lib/sync/webhook.js
@@ -66,8 +66,7 @@ module.exports = (app, queues) => async function (job) {
     try {
       await newrelic.startSegment('webhook handler', true, async () => callback(context, jiraClient, util));
     } catch (err) {
-      // TODO will remove. Using this for local dev
-      context.log('caught an error', { err });
+      context.log.debug('Caught an error running webhook handler', { err });
       job.sentry.captureException(err);
     }
   }

--- a/lib/sync/webhook.js
+++ b/lib/sync/webhook.js
@@ -1,0 +1,75 @@
+const { Subscription } = require('../models');
+const enhanceOctokit = require('../config/enhance-octokit');
+const getJiraClient = require('../jira/client');
+const getJiraUtil = require('../jira/util');
+const newrelic = require('newrelic');
+const pullRequest = require('../github/pull-request');
+
+const jobOpts = {
+  removeOnFail: true,
+  attempts: 3,
+};
+
+module.exports = (app, queues) => async function (job) {
+  const { callbackName, context } = job.data;
+  const gitHubInstallationId = context.payload.installation.id;
+  const github = await app.auth(gitHubInstallationId);
+  enhanceOctokit(github, app.log);
+  context.log = app.log.child({ gitHubInstallationId });
+  context.github = github;
+
+  let webhookEvent = context.name;
+  if (context.payload.action) {
+    webhookEvent = `${webhookEvent}.${context.payload.action}`;
+  }
+  newrelic.addCustomAttributes({
+    'Webhook ID': context.id,
+    'Webhook Event': webhookEvent,
+    Repository: context.payload.repository,
+  });
+  job.sentry.setTag('webhookId', context.id);
+  job.sentry.setTag('transaction', `webhook:${webhookEvent}`);
+  job.sentry.setExtra('GitHub Payload', {
+    event: context.name,
+    action: context.payload.action,
+    id: context.id,
+  });
+
+  const subscriptions = await Subscription.getAllForInstallation(gitHubInstallationId);
+  if (!subscriptions.length) {
+    context.log({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');
+    return;
+  }
+  context.log('subscriptions', { subscriptions });
+
+  for (const subscription of subscriptions) {
+    const { jiraHost } = subscription;
+    job.sentry.setTag('jiraHost', jiraHost);
+    job.sentry.setTag('gitHubInstallationId', gitHubInstallationId);
+    job.sentry.setUser({ jiraHost, gitHubInstallationId });
+    context.log = context.log.child({ jiraHost });
+    if (context.timedout) {
+      Sentry.captureMessage('Timed out jira middleware iterating subscriptions');
+      context.log.error({ timeout: true, timeoutElapsed: context.timedout }, `Timing out at after ${context.timedout}ms`);
+      return;
+    }
+
+    const jiraClient = await getJiraClient(jiraHost, gitHubInstallationId, context.log);
+    if (jiraClient == null) {
+      // Don't call callback if we have no jiraClient
+      context.log.error({ noop: 'no_jira_client' }, `No enabled installation found for ${jiraHost}.`);
+      return;
+    }
+    const util = getJiraUtil(jiraClient);
+
+    const callback = pullRequest;
+
+    try {
+      await newrelic.startSegment('webhook handler', true, async () => callback(context, jiraClient, util));
+    } catch (err) {
+      // TODO will remove. Using this for local dev
+      context.log('caught an error', { err });
+      job.sentry.captureException(err);
+    }
+  }
+};

--- a/lib/sync/webhook.js
+++ b/lib/sync/webhook.js
@@ -40,7 +40,6 @@ module.exports = (app, queues) => async function (job) {
     context.log({ noop: 'no_subscriptions' }, 'Halting futher execution since no subscriptions were found');
     return;
   }
-  context.log('subscriptions', { subscriptions });
 
   for (const subscription of subscriptions) {
     const { jiraHost } = subscription;

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -1,6 +1,7 @@
 const Queue = require('bull');
 const Sentry = require('@sentry/node');
 
+const webhook = require('../sync/webhook');
 const { discovery } = require('../sync/discovery');
 const { processInstallation } = require('../sync/installation');
 const { processPush } = require('../transforms/push');
@@ -27,6 +28,7 @@ const queueOpts = { defaultJobOptions: { removeOnComplete: true } };
 
 // Setup queues
 const queues = {
+  webhook: new Queue('Webhook', REDIS_URL, queueOpts),
   discovery: new Queue('Content discovery', REDIS_URL, queueOpts),
   installation: new Queue('Initial sync', REDIS_URL, queueOpts),
   push: new Queue('Push transformation', REDIS_URL, queueOpts),
@@ -98,14 +100,20 @@ function sentryMiddleware(jobHandler) {
 function newrelicMiddleware(jobHandler) {
   return async (job) => {
     newrelic.startBackgroundTransaction(`job ${job.queue.name}`, 'worker queue', async () => {
-      app.log('ZMOTEST', { here: 'true', data: job.data, opts: job.opts });
       const transaction = newrelic.getTransaction();
+
+      const jobData = Object.assign({}, job.data);
+      // Don't log webhook payload to newrelic
+      if (jobData.context) {
+        jobData.context = '[FILTERED]';
+      }
+
       newrelic.addCustomAttributes({
         Queue: job.queue.name,
         'Job Id': job.id,
 
         // NewRelic wants 'primitive' types. Sending a hash will be dropped
-        'Job Arguments': JSON.stringify(job.data),
+        'Job Arguments': JSON.stringify(jobData),
         'Job Options': JSON.stringify(job.opts),
       });
 
@@ -131,6 +139,7 @@ module.exports = {
   queues,
 
   start() {
+    queues.webhook.process(5, commonMiddleware(webhook(app, queues)));
     queues.discovery.process(5, commonMiddleware(discovery(app, queues)));
     queues.installation.process(Number(CONCURRENT_WORKERS), commonMiddleware(processInstallation(app, queues)));
     queues.push.process(Number(CONCURRENT_WORKERS), commonMiddleware(limiterPerInstallation(processPush(app))));

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -139,7 +139,7 @@ module.exports = {
   queues,
 
   start() {
-    queues.webhook.process(5, commonMiddleware(webhook(app, queues)));
+    queues.webhook.process(Number(CONCURRENT_WORKERS), commonMiddleware(webhook(app, queues)));
     queues.discovery.process(5, commonMiddleware(discovery(app, queues)));
     queues.installation.process(Number(CONCURRENT_WORKERS), commonMiddleware(processInstallation(app, queues)));
     queues.push.process(Number(CONCURRENT_WORKERS), commonMiddleware(limiterPerInstallation(processPush(app))));

--- a/test/setup/env.js
+++ b/test/setup/env.js
@@ -12,6 +12,10 @@ const defaults = Object.assign({
   // Generate a secure, random one with `openssl rand -hex 32` in your .env file
   STORAGE_SECRET: '8cad66340bc92edbae2ae3a792d351f48c61d1d8efe7b2d9408b0025c1f7f845',
   SETUP: 'yes', // indicates that the setup did run
+
+  // use a different database than development
+  // that way tests don't enqueue jobs that development tries to run
+  REDIS_URL: 'redis://127.0.0.1:6379/2',
 }, process.env);
 
 Object.assign(process.env, defaults);

--- a/test/setup/env.js
+++ b/test/setup/env.js
@@ -16,6 +16,7 @@ const defaults = Object.assign({
   // use a different database than development
   // that way tests don't enqueue jobs that development tries to run
   REDIS_URL: 'redis://127.0.0.1:6379/2',
+  NO_BACKGROUND_WEBHOOKS: 'true',
 }, process.env);
 
 Object.assign(process.env, defaults);

--- a/test/setup/index.js
+++ b/test/setup/index.js
@@ -2,3 +2,10 @@ require('./env');
 require('./testdouble');
 require('./app');
 require('./matchers/to-have-sent-metrics');
+const Redis = require('ioredis');
+
+const redis = new Redis(process.env.REDIS_URL);
+
+beforeEach(async () => {
+  await redis.flushdb();
+});

--- a/test/unit/github/middleware.test.js
+++ b/test/unit/github/middleware.test.js
@@ -2,40 +2,44 @@ const { logger } = require('probot/lib/logger');
 const Octokit = require('@octokit/rest');
 
 const { Installation, Subscription } = require('../../../lib/models');
-const middleware = require('../../../lib/github/middleware');
+const { middleware, workerMiddleware } = require('../../../lib/github/middleware');
+const { queues } = require('../../../lib/worker');
 
 describe('Probot event middleware', () => {
-  describe('when processing fails for one subscription', () => {
-    let context;
-    let handlerCalls;
+  let context;
+  let handlerCalls;
 
-    beforeEach(async () => {
-      context = {
-        payload: {
-          sender: { type: 'not bot' },
-          installation: { id: 1234 },
-        },
-        github: Octokit(),
-        log: logger,
-      };
+  beforeEach(async () => {
+    context = {
+      payload: {
+        sender: { type: 'not bot' },
+        installation: { id: 1234 },
+      },
+      github: Octokit(),
+      log: logger,
+    };
 
-      Installation.getForHost = jest.fn((jiraHost) => {
-        const installations = [
-          { jiraHost: 'https://foo.atlassian.net', sharedSecret: 'secret1' },
-          { jiraHost: 'https://bar.atlassian.net', sharedSecret: 'secret2' },
-          { jiraHost: 'https://baz.atlassian.net', sharedSecret: 'secret3' },
-        ];
+    Installation.getForHost = jest.fn((jiraHost) => {
+      const installations = [
+        { jiraHost: 'https://foo.atlassian.net', sharedSecret: 'secret1' },
+        { jiraHost: 'https://bar.atlassian.net', sharedSecret: 'secret2' },
+        { jiraHost: 'https://baz.atlassian.net', sharedSecret: 'secret3' },
+      ];
 
-        return installations.find(installation => installation.jiraHost === jiraHost);
-      });
+      return installations.find(installation => installation.jiraHost === jiraHost);
+    });
 
-      Subscription.getAllForInstallation = jest.fn().mockReturnValue([
-        { jiraHost: 'https://foo.atlassian.net' },
-        { jiraHost: 'https://bar.atlassian.net' },
-        { jiraHost: 'https://baz.atlassian.net' },
-      ]);
+    Subscription.getAllForInstallation = jest.fn().mockReturnValue([
+      { jiraHost: 'https://foo.atlassian.net' },
+      { jiraHost: 'https://bar.atlassian.net' },
+      { jiraHost: 'https://baz.atlassian.net' },
+    ]);
 
-      handlerCalls = [];
+    handlerCalls = [];
+  });
+
+  describe('inline webhook processing', () => {
+    it('calls handler for each subscription, even when one fails', async () => {
       const handler = middleware((context, jiraClient, util) => {
         handlerCalls.push([context, jiraClient, util]);
 
@@ -45,10 +49,24 @@ describe('Probot event middleware', () => {
       });
 
       await handler(context);
+      expect(handlerCalls.length).toEqual(3);
+    });
+  });
+
+  describe('async webhook processing', () => {
+    it('enqueues webhook job if there is at least one subscription', async () => {
+      const handler = workerMiddleware('pullRequest');
+      await handler(context);
+      const counts = await queues.webhook.getJobCounts();
+      expect(counts.waiting).toEqual(1);
     });
 
-    it('calls handler for each subscription', async () => {
-      expect(handlerCalls.length).toEqual(3);
+    it('does not enqueue anything if there are no subscriptions', async () => {
+      context.payload.installation.id = 9999; // this doesn't exist in the test fixtures
+      const handler = workerMiddleware('pullRequest');
+      await handler(context);
+      const counts = await queues.webhook.getJobCounts();
+      expect(counts.waiting).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
This moves the processing of just `pullRequest` events to a background job. There's still lots that we can do in this realm, but I'm hoping this can be a one-by-one transition of our webhook handlers to address our load issues.