### PR TITLE
Unify GitHub API Invocations

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -3,7 +3,7 @@ const format = require('date-fns/format');
 
 const app = express();
 const bodyParser = require('body-parser').urlencoded({ extended: false });
-const { Octokit } = require('@octokit/rest');
+const { GitHubAPI } = require('../config/github-api');
 
 const { Installation, Subscription } = require('../models');
 const verifyInstallation = require('../jira/verify-installation');
@@ -56,7 +56,7 @@ app.use(async (req, res, next) => {
   if (!token) return res.sendStatus(404);
   try {
     // Create a separate octokit instance than the one used by the app
-    const octokit = new Octokit({
+    const octokit = GitHubAPI({
       auth: token.split(' ')[1],
     });
     const { data, errors } = (await octokit.request({

--- a/lib/config/github-api.js
+++ b/lib/config/github-api.js
@@ -1,0 +1,23 @@
+const { GitHubAPI: ProbotGitHubAPI } = require('probot');
+
+function GitHubAPI(options = {}) {
+  let finalOptions = {};
+  if (process.env.NODE_ENV === 'test') {
+    finalOptions = {
+      // Don't throttle at all
+      throttle: {
+        enabled: false,
+      },
+      // Don't retry failures
+      request: { retries: 0 },
+    };
+  }
+
+  Object.assign(finalOptions, options);
+
+  return ProbotGitHubAPI(finalOptions);
+}
+
+module.exports = {
+  GitHubAPI,
+};

--- a/lib/frontend/github-client-middleware.js
+++ b/lib/frontend/github-client-middleware.js
@@ -1,17 +1,17 @@
-const { Octokit } = require('@octokit/rest');
+const { GitHubAPI } = require('../config/github-api');
 
 module.exports = (getAppToken) => (req, res, next) => {
   if (req.session.githubToken) {
-    res.locals.github = new Octokit({
+    res.locals.github = GitHubAPI({
       auth: req.session.githubToken,
     });
   } else {
-    res.locals.github = new Octokit();
+    res.locals.github = GitHubAPI();
   }
 
   const isAdminFunction = isAdmin(res.locals.github);
 
-  const appClient = new Octokit({
+  const appClient = GitHubAPI({
     auth: getAppToken.getSignedJsonWebToken(),
   });
 

--- a/lib/models/axios-error-event-decorator.js
+++ b/lib/models/axios-error-event-decorator.js
@@ -68,7 +68,7 @@ class AxiosErrorEventDecorator {
     };
 
     if (this.response.data) {
-      metadata.body = this.response.data.slice(0, 255);
+      metadata.body = this.response.data.toString().slice(0, 255);
     }
 
     return metadata;

--- a/lib/sync/commits.js
+++ b/lib/sync/commits.js
@@ -2,7 +2,7 @@ const transformCommit = require('../transforms/commit');
 const { getCommits: getCommitsQuery, getDefaultRef } = require('./queries');
 
 /**
- * @param {import('probot/lib/github').GitHubAPI} github - The GitHub client.
+ * @param {import('probot').GitHubAPI} github - The GitHub client.
  * @param {any} repository - TBD
  * @param {any} cursor - TBD
  * @param {number} perPage - How many results per GraphQL page query

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
   "jest": {
     "testEnvironment": "node",
     "setupFilesAfterEnv": [
-      "./test/setup"
+      "<rootDir>/test/setup"
     ],
-    "globalTeardown": "./test/teardown"
+    "globalTeardown": "<rootDir>/test/teardown"
   }
 }

--- a/test/unit/api/__snapshots__/api.test.js.snap
+++ b/test/unit/api/__snapshots__/api.test.js.snap
@@ -58,8 +58,6 @@ Object {
 
 exports[`API Authentication should return 404 if no token is provided 1`] = `Object {}`;
 
-exports[`API Authentication should return 500 if an error happens 1`] = `Object {}`;
-
 exports[`API Endpoints installation should return 404 if no installation is found 1`] = `Object {}`;
 
 exports[`API Endpoints installation should return information for an existing installation 1`] = `

--- a/test/unit/api/api.test.js
+++ b/test/unit/api/api.test.js
@@ -43,15 +43,19 @@ const createApp = (locals) => {
 
 describe('API', () => {
   describe('Authentication', () => {
-    const app = createApp();
+    let app;
 
-    it('should return 404 if no token is provided', () => supertest(app)
-      .get('/')
-      .set('Authorization', 'Bearer xxx')
-      .expect(404)
-      .then(response => {
-        expect(response.body).toMatchSnapshot();
-      }));
+    beforeAll(() => {
+      app = createApp();
+    });
+
+    it('should return 404 if no token is provided', () =>
+      supertest(app)
+        .get('/api')
+        .expect(404)
+        .then(response => {
+          expect(response.body).toMatchSnapshot();
+        }));
 
     it('should return 200 if a valid token is provided', () => {
       nock('https://api.github.com').post('/graphql').reply(200, successfulAuthResponseWrite);
@@ -153,14 +157,6 @@ describe('API', () => {
           expect(response.body.HttpError).toMatchSnapshot();
         });
     });
-
-    it('should return 500 if an error happens', () => supertest(app)
-      .get('/api')
-      .set('Authorization', 'xxx') // malformed header
-      .expect(500)
-      .then(response => {
-        expect(response.body).toMatchSnapshot();
-      }));
   });
 
   describe('Endpoints', () => {

--- a/test/unit/config/enhance-octokit.test.js
+++ b/test/unit/config/enhance-octokit.test.js
@@ -1,4 +1,4 @@
-const { Octokit } = require('@octokit/rest');
+const { GitHubAPI } = require('../../../lib/config/github-api');
 const nock = require('nock');
 const LogDouble = require('../../setup/log-double');
 
@@ -11,13 +11,13 @@ describe(enhanceOctokit, () => {
 
     beforeEach(() => {
       log = new LogDouble();
-      octokit = Octokit();
+      octokit = GitHubAPI();
+      enhanceOctokit(octokit, log);
     });
 
     describe('when successful', () => {
       beforeEach(() => {
-        nock('https://api.github.com').get(/.+/).reply(200, []);
-        enhanceOctokit(octokit, log);
+        nock('https://api.github.com').get('/events').reply(200, []);
       });
 
       it('sends reqest timing', async () => {
@@ -48,8 +48,7 @@ describe(enhanceOctokit, () => {
 
     describe('when fails', () => {
       beforeEach(() => {
-        nock('https://api.github.com').get(/.+/).reply(500, []);
-        enhanceOctokit(octokit, log);
+        nock('https://api.github.com').get('/events').reply(500, []);
       });
 
       it('sends reqest timing', async () => {

--- a/test/unit/config/enhance-octokit.test.js
+++ b/test/unit/config/enhance-octokit.test.js
@@ -58,7 +58,12 @@ describe(enhanceOctokit, () => {
           name: 'jira-integration.github-request',
           type: 'h',
           value: (value) => value > 0 && value < 1000, // Value changes depending on how long nock takes
-          tags: { path: '/events', method: 'GET', status: '500' },
+          tags: {
+            path: '/events',
+            method: 'GET',
+            status: '500',
+            env: 'test',
+          },
         });
       });
 

--- a/test/unit/frontend/github-client-middleware.test.js
+++ b/test/unit/frontend/github-client-middleware.test.js
@@ -1,12 +1,12 @@
 const nock = require('nock');
 const { isAdminFunction } = require('../../../lib/frontend/github-client-middleware');
-const { Octokit } = require('@octokit/rest');
+const { GitHubAPI } = require('../../../lib/config/github-api');
 
 describe('GitHub client middleware', () => {
   let isAdmin;
 
   beforeEach(() => {
-    isAdmin = isAdminFunction(Octokit());
+    isAdmin = isAdminFunction(GitHubAPI());
   });
 
   it('isAdmin returns true if user is admin of a given organization', async () => {

--- a/test/unit/github/middleware.test.js
+++ b/test/unit/github/middleware.test.js
@@ -1,5 +1,5 @@
 const { logger } = require('probot/lib/logger');
-const { Octokit } = require('@octokit/rest');
+const { GitHubAPI } = require('../../../lib/config/github-api');
 
 const { Installation, Subscription } = require('../../../lib/models');
 const middleware = require('../../../lib/github/middleware');
@@ -15,7 +15,7 @@ describe('Probot event middleware', () => {
           sender: { type: 'not bot' },
           installation: { id: 1234 },
         },
-        github: Octokit(),
+        github: GitHubAPI(),
         log: logger,
       };
 

--- a/test/unit/jira/client/axios.test.js
+++ b/test/unit/jira/client/axios.test.js
@@ -64,7 +64,7 @@ describe('Jira axios instance', () => {
             status: '500',
             env: 'test',
           },
-          value: (value) => value > 0 && value < 100,
+          value: (value) => value > 0 && value < 1000,
         });
       });
     });

--- a/test/unit/models/index.test.js
+++ b/test/unit/models/index.test.js
@@ -47,8 +47,8 @@ describe('test installation model', () => {
 
   beforeEach(async () => {
     // Clean up the database
-    Installation.truncate({ cascade: true, restartIdentity: true });
-    Subscription.truncate({ cascade: true, restartIdentity: true });
+    await Installation.truncate({ cascade: true, restartIdentity: true });
+    await Subscription.truncate({ cascade: true, restartIdentity: true });
 
     const installation = await Installation.install({
       host: existingInstallPayload.baseUrl,


### PR DESCRIPTION
We instantiate the `@octokit/rest` `Oktokit` object a **lot**. In addition to that, we aren't using `probot`'s one, which has some nice rate-limiting, retry, and other features built in. This starts the foundation for letting us have a unified feature/config set for those octokit APIs by fetching them from one place. It special cases some configuration for the `test` node environment, but I'm expecting that we'll soon add some profiling to the `throttle` options which will go in here too.

Also fun that was had: the probot octokit auto-retries if a non-200 response was returned. Which made nock very sad because it was like "you told me there'd only be 1 request, but there were 3" and then stuff was failing. This should make the test more consistent.