### PR TITLE
Quick-Fix permissions

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -37,7 +37,7 @@ const viewerPermissionQuery = `{
     login
     isEmployee
     organization(login: "github") {
-      repository(name: "ecosystem-primitives") {
+      repository(name: "ce-extensibility") {
         viewerPermission
       }
     }

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -95,7 +95,7 @@ app.use(async (req, res, next) => {
       res.status(401);
       return res.json({
         error: 'Unauthorized',
-        message: 'Token provided does not have `WRITE` or `ADMIN` access to the @github/ecosystem-primitives repo.',
+        message: 'Token provided does not have `WRITE` or `ADMIN` access to the @github/ce-extensibility repo.',
       });
     }
 

--- a/lib/jira/connect.js
+++ b/lib/jira/connect.js
@@ -7,7 +7,7 @@ module.exports = async (req, res) => {
   return res.status(200)
     .json({
       // Will need to be set to `true` once we verify the app will work with
-      // GDPR compliant APIs. Ref: https://github.com/github/ecosystem-primitives/issues/220
+      // GDPR compliant APIs. Ref: https://github.com/github/ce-extensibility/issues/220
       apiMigrations: {
         gdpr: false,
       },

--- a/test/unit/api/__snapshots__/api.test.js.snap
+++ b/test/unit/api/__snapshots__/api.test.js.snap
@@ -32,7 +32,7 @@ Object {
     login
     isEmployee
     organization(login: \\"github\\") {
-      repository(name: \\"ecosystem-primitives\\") {
+      repository(name: \\"ce-extensibility\\") {
         viewerPermission
       }
     }


### PR DESCRIPTION
The repo that we use to check permissions for the private apis changed names. This is a quick-fix but a bigger fix is needed.

(bigger fix needed)