### PR TITLE
Switch pull request sync flow to rest api

### DIFF
--- a/lib/sync/pull-request.js
+++ b/lib/sync/pull-request.js
@@ -1,57 +1,89 @@
+const url = require('url');
 const transformPullRequest = require('./transforms/pull-request');
-const { getPullRequests: getPullRequestQuery } = require('./queries');
-const { logger } = require('probot/lib/logger');
-
 const statsd = require('../config/statsd');
 
 /**
+ * @typedef {object} RepositoryObject
+ * @property {number} id
+ * @property {string} name
+ * @property {object} owner
+ * @property {string} owner.login
+ * @property {string} html_url
+ * @property {string} full_name
+ */
+
+/**
+ * Find the next page number from the response headers.
+ *
+ * @param {{link: string}} headers - The headers from the API response.
+ * @returns {number|undefined} The next page number.
+ */
+function getNextPage(headers = {}) {
+  const nextUrl = ((headers.link || '').match(/<([^>]+)>;\s*rel="next"/) || [])[1];
+  if (!nextUrl) {
+    return;
+  }
+  const parsed = url.parse(nextUrl).query.split('&');
+  let nextPage;
+  parsed.forEach((query) => {
+    const [key, value] = query.split('=');
+    if (key === 'page') {
+      nextPage = Number(value);
+    }
+  });
+  return nextPage;
+}
+
+/**
  * @param {import('probot').GitHubAPI} github - The GitHub API Object
- * @param {any} repository - TBD
- * @param {any} cursor - TBD
+ * @param {RepositoryObject} repository - TBD
+ * @param {string|number} cursor - TBD
  * @param {any} perPage - TBD
  * @returns {any} TBD
  */
-exports.getPullRequests = async (github, repository, cursor, perPage) => {
+async function getPullRequests(github, repository, cursor, perPage) {
+  /** @type {number} */
+  let status;
+  /** @type {{link: string}} */
+  let headers;
+  /** @type {import('@octokit/rest').Octokit.PullsListResponse} */
   let edges;
+  if (!cursor) {
+    cursor = 1;
+  } else {
+    cursor = Number(cursor);
+  }
   const vars = {
     owner: repository.owner.login,
     repo: repository.name,
     per_page: perPage,
-    cursor,
+    page: cursor,
   };
 
   let asyncTags = [];
   await statsd.asyncTimer(
     async () => {
-      try {
-        ({ edges } = (await github.graphql(getPullRequestQuery, vars)).repository.pullRequests);
-        asyncTags.push('status:200');
-      } catch (error) {
-        logger.error('GraphQL Query Error for Sync Pull Request', error);
-        if (error.status) {
-          asyncTags.push(`status:${error.status}`);
-        } else if (error.httpError && error.httpError.status) {
-          asyncTags.push(`status:${error.httpError.status}`);
-        } else {
-          asyncTags.push('status:exception');
-        }
-        throw error;
-      }
+      ({ data: edges, status, headers } = (await github.pulls.list({
+        ...vars,
+        state: 'all',
+        sort: 'created',
+        direction: 'desc',
+      })));
+      asyncTags.push(`status:${status}`);
     },
-    'graphql.sync_pull_request',
+    'rest.sync_pull_request',
     1,
     asyncTags,
   )();
 
-  let pullRequests = await Promise.all(edges.map(async ({ node: pull }) => {
-    // Count of comments causes graphql to time out, fetch it from the regular API
-    const pr = await github.pulls.get({
-      owner: repository.owner.login,
-      repo: repository.name,
-      pull_number: pull.number,
-    });
-    pull.comments = { totalCount: pr.data.comments };
-    const { data } = transformPullRequest({ pull_request: pull, repository }, pull.author);
+  const nextPage = getNextPage(headers);
+
+  edges.forEach((edge) => {
+    edge.cursor = nextPage;
+  });
+
+  let pullRequests = await Promise.all(edges.map(async (pull) => {
+    const { data } = await transformPullRequest({ pullRequest: pull, repository }, pull.user, github);
     return data && data.pullRequests[0];
   }));
 
@@ -65,4 +97,9 @@ exports.getPullRequests = async (github, repository, cursor, perPage) => {
     updateSequenceId: Date.now(),
   };
   return { edges, jiraPayload };
+}
+
+module.exports = {
+  getPullRequests,
+  getNextPage,
 };

--- a/lib/sync/pull-request.js
+++ b/lib/sync/pull-request.js
@@ -79,6 +79,8 @@ async function getPullRequests(github, repository, cursor, perPage) {
   // Force us to go to a non-existant page if we're past the max number of pages
   const nextPage = getNextPage(headers) || cursor + 1;
 
+  // Attach the "cursor" (next page number) to each edge, because the function that uses this data
+  // fetches the cursor from one of the edges instead of letting us return it explicitly.
   edges.forEach((edge) => {
     edge.cursor = nextPage;
   });

--- a/lib/sync/pull-request.js
+++ b/lib/sync/pull-request.js
@@ -78,7 +78,6 @@ async function getPullRequests(github, repository, cursor, perPage) {
 
   // Force us to go to a non-existant page if we're past the max number of pages
   const nextPage = getNextPage(headers) || cursor + 1;
-  console.log(`CURSOR: ${cursor}, NEXTPAGE: ${nextPage}`);
 
   edges.forEach((edge) => {
     edge.cursor = nextPage;

--- a/lib/sync/pull-request.js
+++ b/lib/sync/pull-request.js
@@ -76,7 +76,9 @@ async function getPullRequests(github, repository, cursor, perPage) {
     asyncTags,
   )();
 
-  const nextPage = getNextPage(headers);
+  // Force us to go to a non-existant page if we're past the max number of pages
+  const nextPage = getNextPage(headers) || cursor + 1;
+  console.log(`CURSOR: ${cursor}, NEXTPAGE: ${nextPage}`);
 
   edges.forEach((edge) => {
     edge.cursor = nextPage;

--- a/lib/sync/pull-request.js
+++ b/lib/sync/pull-request.js
@@ -68,6 +68,11 @@ async function getPullRequests(github, repository, cursor, perPage) {
         state: 'all',
         sort: 'created',
         direction: 'desc',
+        // Retry up to 6 times pausing for 10s, for *very* large repos we need to wait a while for the result to succeed in dotcom
+        request: {
+          retries: 6,
+          retryAfter: 10,
+        },
       })));
       asyncTags.push(`status:${status}`);
     },

--- a/lib/sync/transforms/pull-request.js
+++ b/lib/sync/transforms/pull-request.js
@@ -1,19 +1,27 @@
 const parseSmartCommit = require('../../transforms/smart-commit');
 
-function mapStatus({ state, merged }) {
-  if (state === 'MERGED') {
+/**
+ * @param {import('@octokit/rest').Octokit.PullsListResponseItem} payload - The pull request details
+ */
+function mapStatus({ state, merged_at }) {
+  if (state === 'merged') {
     return 'MERGED';
-  } else if (state === 'OPEN') {
+  } else if (state === 'open') {
     return 'OPEN';
-  } else if (state === 'CLOSED' && merged) {
+  } else if (state === 'closed' && merged_at) {
     return 'MERGED';
-  } else if (state === 'CLOSED' && !merged) {
+  } else if (state === 'closed' && !merged_at) {
     return 'DECLINED';
   } else {
     return 'UNKNOWN';
   }
 }
 
+/**
+ * Get the author or a ghost user.
+ *
+ * @param {import('@octokit/rest').Octokit.PullsListResponseItemUser} author - The pull request author
+ */
 function getAuthor(author) {
   // If author is null, return the ghost user
   if (!author) {
@@ -25,20 +33,32 @@ function getAuthor(author) {
   }
 
   return {
-    avatar: author.avatarUrl,
+    avatar: author.avatar_url,
     name: author.login,
     url: author.url,
   };
 }
 
-module.exports = (payload, author) => {
-  // eslint-disable-next-line camelcase
-  const { pull_request: pullRequest, repository } = payload;
+/**
+ * @param {{pullRequest: import('@octokit/rest').Octokit.PullsListResponseItem, repository: import('../pull-request').RepositoryObject}} payload - The pull request details
+ * @param {import('@octokit/rest').Octokit.PullsListResponseItemUser} author - The pull request author
+ * @param {import('probot').GitHubAPI} github - The GitHub API Object
+ */
+module.exports = async (payload, author, github) => {
+  const { pullRequest, repository } = payload;
   const { issueKeys } = parseSmartCommit(pullRequest.title);
 
   if (!issueKeys) {
     return {};
   }
+
+  // Comment Count is required by the Jira API, but only do this second fetch if we have issue keys.
+  const prGet = await github.pulls.get({
+    owner: repository.owner.login,
+    repo: repository.name,
+    pull_number: pullRequest.number,
+  });
+  const commentCount = prGet.data.comments;
 
   return {
     data: {
@@ -47,16 +67,16 @@ module.exports = (payload, author) => {
       pullRequests: [
         {
           author: getAuthor(author),
-          commentCount: pullRequest.comments.totalCount,
-          destinationBranch: `${repository.html_url}/tree/${pullRequest.baseRef ? pullRequest.baseRef.name : ''}`,
+          commentCount,
+          destinationBranch: `${repository.html_url}/tree/${pullRequest.base ? pullRequest.base.ref : ''}`,
           displayId: `#${pullRequest.number}`,
           id: pullRequest.number,
           issueKeys,
-          lastUpdate: pullRequest.updatedAt,
-          sourceBranch: `${pullRequest.headRef ? pullRequest.headRef.name : ''}`,
-          sourceBranchUrl: `${repository.html_url}/tree/${pullRequest.headRef ? pullRequest.headRef.name : ''}`,
+          lastUpdate: pullRequest.updated_at,
+          sourceBranch: `${pullRequest.head ? pullRequest.head.ref : ''}`,
+          sourceBranchUrl: `${repository.html_url}/tree/${pullRequest.head ? pullRequest.head.ref : ''}`,
           status: mapStatus(pullRequest),
-          timestamp: pullRequest.updatedAt,
+          timestamp: pullRequest.updated_at,
           title: pullRequest.title,
           url: pullRequest.url,
           updateSequenceId: Date.now(),

--- a/lib/sync/transforms/pull-request.js
+++ b/lib/sync/transforms/pull-request.js
@@ -78,7 +78,7 @@ module.exports = async (payload, author, github) => {
           status: mapStatus(pullRequest),
           timestamp: pullRequest.updated_at,
           title: pullRequest.title,
-          url: pullRequest.url,
+          url: pullRequest.html_url,
           updateSequenceId: Date.now(),
         },
       ],

--- a/lib/sync/transforms/pull-request.js
+++ b/lib/sync/transforms/pull-request.js
@@ -52,16 +52,10 @@ module.exports = async (payload, author, github) => {
     return {};
   }
 
-  // Comment Count is required by the Jira API, but only do this second fetch if we have issue keys.
-  // Retry up to 6 times pausing for 10s, for *very* large repos we need to wait a while for the result to succeed in dotcom
   const prGet = await github.pulls.get({
     owner: repository.owner.login,
     repo: repository.name,
     pull_number: pullRequest.number,
-    request: {
-      retries: 6,
-      retryAfter: 10,
-    },
   });
   const commentCount = prGet.data.comments;
 

--- a/lib/sync/transforms/pull-request.js
+++ b/lib/sync/transforms/pull-request.js
@@ -53,10 +53,15 @@ module.exports = async (payload, author, github) => {
   }
 
   // Comment Count is required by the Jira API, but only do this second fetch if we have issue keys.
+  // Retry up to 6 times pausing for 10s, for *very* large repos we need to wait a while for the result to succeed in dotcom
   const prGet = await github.pulls.get({
     owner: repository.owner.login,
     repo: repository.name,
     pull_number: pullRequest.number,
+    request: {
+      retries: 6,
+      retryAfter: 10,
+    },
   });
   const commentCount = prGet.data.comments;
 

--- a/test/unit/sync/pull-requests.test.js
+++ b/test/unit/sync/pull-requests.test.js
@@ -51,15 +51,15 @@ describe('sync/pull-request', () => {
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
 
-    const { pullsNoLastCursor, pullsWithLastCursor } = require('../../fixtures/api/graphql/pull-queries');
-    const pullWithKeyInTitle = require('../../fixtures/api/graphql/pull-request-nodes.json');
+    const pullRequestList = JSON.parse(JSON.stringify(require('../../fixtures/api/pull-request-list.json')));
+    pullRequestList[0].title = '[TES-15] Evernote Test';
 
-    nock('https://api.github.com').post('/graphql', pullsNoLastCursor)
-      .reply(200, pullWithKeyInTitle);
-    nock('https://api.github.com').post('/graphql', pullsWithLastCursor)
-      .reply(200, pullWithKeyInTitle);
-    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls/96')
+    // GET /repos/:owner/:repo/pulls
+    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls?per_page=20&page=1&state=all&sort=created&direction=desc')
+      .reply(200, pullRequestList);
+    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls/51')
       .reply(200, { comments: 0 });
+
 
     const queues = {
       installation: {
@@ -79,22 +79,22 @@ describe('sync/pull-request', () => {
           pullRequests: [
             {
               author: {
-                avatar: 'https://avatars0.githubusercontent.com/u/13207348?v=4',
-                name: 'tcbyrd',
-                url: 'https://github.com/tcbyrd',
+                avatar: 'https://avatars0.githubusercontent.com/u/173?v=4',
+                name: 'bkeepers',
+                url: 'https://api.github.com/users/bkeepers',
               },
               commentCount: 0,
-              destinationBranch: 'test-repo-url/tree/master',
-              displayId: '#96',
-              id: 96,
+              destinationBranch: 'test-repo-url/tree/devel',
+              displayId: '#51',
+              id: 51,
               issueKeys: ['TES-15'],
-              lastUpdate: '2018-08-23T21:38:05Z',
-              sourceBranch: 'evernote-test',
-              sourceBranchUrl: 'test-repo-url/tree/evernote-test',
-              status: 'OPEN',
-              timestamp: '2018-08-23T21:38:05Z',
-              title: '[TES-15] Evernote test',
-              url: 'https://github.com/tcbyrd/testrepo/pull/96',
+              lastUpdate: '2018-05-04T14:06:56Z',
+              sourceBranch: 'use-the-force',
+              sourceBranchUrl: 'test-repo-url/tree/use-the-force',
+              status: 'DECLINED',
+              timestamp: '2018-05-04T14:06:56Z',
+              title: '[TES-15] Evernote Test',
+              url: 'https://api.github.com/repos/integrations/test/pulls/51',
               updateSequenceId: 12345678,
             },
           ],
@@ -102,9 +102,7 @@ describe('sync/pull-request', () => {
           updateSequenceId: 12345678,
         },
       ],
-      properties: {
-        installationId: 1234,
-      },
+      properties: { installationId: 1234 },
     }));
   });
 
@@ -115,15 +113,8 @@ describe('sync/pull-request', () => {
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
 
-    const { pullsNoLastCursor, pullsWithLastCursor } = require('../../fixtures/api/graphql/pull-queries');
-    const fixture = require('../../fixtures/api/graphql/pull-request-empty-nodes.json');
-
-    nock('https://api.github.com').post('/graphql', pullsNoLastCursor)
-      .reply(200, fixture);
-    nock('https://api.github.com').post('/graphql', pullsWithLastCursor)
-      .reply(200, fixture);
-    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls/96')
-      .reply(200, { comments: 0 });
+    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls?per_page=20&page=1&state=all&sort=created&direction=desc')
+      .reply(200, []);
 
     td.when(jiraApi.post(), { ignoreExtraArgs: true })
       .thenThrow(new Error('test error'));
@@ -147,10 +138,11 @@ describe('sync/pull-request', () => {
 
     nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
 
-    const fixture = require('../../fixtures/api/graphql/pull-request-no-keys.json');
-    nock('https://api.github.com').post('/graphql').reply(200, fixture);
-    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls/96')
-      .reply(200, { comments: 0 });
+    const pullRequestList = JSON.parse(JSON.stringify(require('../../fixtures/api/pull-request-list.json')));
+
+    // GET /repos/:owner/:repo/pulls
+    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls?per_page=20&page=1&state=all&sort=created&direction=desc')
+      .reply(200, pullRequestList);
 
     td.when(jiraApi.post(), { ignoreExtraArgs: true })
       .thenThrow(new Error('test error'));

--- a/test/unit/sync/pull-requests.test.js
+++ b/test/unit/sync/pull-requests.test.js
@@ -94,7 +94,7 @@ describe('sync/pull-request', () => {
               status: 'DECLINED',
               timestamp: '2018-05-04T14:06:56Z',
               title: '[TES-15] Evernote Test',
-              url: 'https://api.github.com/repos/integrations/test/pulls/51',
+              url: 'https://github.com/integrations/test/pull/51',
               updateSequenceId: 12345678,
             },
           ],

--- a/test/unit/sync/transforms/pull-request.test.js
+++ b/test/unit/sync/transforms/pull-request.test.js
@@ -1,30 +1,11 @@
 const transformPullRequest = require('../../../../lib/sync/transforms/pull-request');
 
 describe('pull_request transform', () => {
-  it('should send the ghost user to Jira when GitHub user has been deleted', () => {
+  it('should send the ghost user to Jira when GitHub user has been deleted', async () => {
+    const pullRequestList = JSON.parse(JSON.stringify(require('../../../fixtures/api/pull-request-list.json')));
+    pullRequestList[0].title = '[TES-123] Evernote Test';
     const payload = {
-      pull_request: {
-        author: null, // GraphQL returns `null` when author of PR has been deleted from GitHub
-        databaseId: 1234568,
-        comments: {
-          totalCount: 1,
-        },
-        repository: {
-          url: 'https://github.com/test-owner/test-repo',
-        },
-        baseRef: {
-          name: 'master',
-        },
-        headRef: {
-          name: 'test-branch',
-        },
-        number: 123,
-        state: 'MERGED',
-        title: 'TES-123 Test Pull Request title',
-        body: '',
-        updatedAt: '2018-04-18T15:42:13Z',
-        url: 'https://github.com/test-owner/test-repo/pull/123',
-      },
+      pullRequest: pullRequestList[0],
       repository: {
         id: 1234568,
         name: 'test-repo',
@@ -33,10 +14,16 @@ describe('pull_request transform', () => {
         html_url: 'https://github.com/test-owner/test-repo',
       },
     };
+    payload.pullRequest.user = null;
+    const githubMock = {
+      pulls: {
+        get: () => ({ data: { comments: 1 } }),
+      },
+    };
 
     Date.now = jest.fn(() => 12345678);
 
-    const { data } = transformPullRequest(payload, payload.pull_request.author);
+    const { data } = await transformPullRequest(payload, payload.pullRequest.user, githubMock);
     expect(data).toMatchObject({
       id: 1234568,
       name: 'test-owner/test-repo',
@@ -50,17 +37,17 @@ describe('pull_request transform', () => {
             url: 'https://github.com/ghost',
           },
           commentCount: 1,
-          destinationBranch: 'https://github.com/test-owner/test-repo/tree/master',
-          displayId: '#123',
-          id: 123,
+          destinationBranch: 'https://github.com/test-owner/test-repo/tree/devel',
+          displayId: '#51',
+          id: 51,
           issueKeys: ['TES-123'],
-          lastUpdate: '2018-04-18T15:42:13Z',
-          sourceBranch: 'test-branch',
-          sourceBranchUrl: 'https://github.com/test-owner/test-repo/tree/test-branch',
-          status: 'MERGED',
-          timestamp: '2018-04-18T15:42:13Z',
-          title: 'TES-123 Test Pull Request title',
-          url: 'https://github.com/test-owner/test-repo/pull/123',
+          lastUpdate: pullRequestList[0].updated_at,
+          sourceBranch: 'use-the-force',
+          sourceBranchUrl: 'https://github.com/test-owner/test-repo/tree/use-the-force',
+          status: 'DECLINED',
+          timestamp: pullRequestList[0].updated_at,
+          title: pullRequestList[0].title,
+          url: 'https://github.com/integrations/test/pull/51',
           updateSequenceId: 12345678,
         },
       ],


### PR DESCRIPTION
The graphql endpoint is timing out and it's breaking some customers with very large repos (> 100k pull requests). The rest api is a bit more performant (in local testing) and doesn't error out on large repos like graphql does. This PR rewrites the logic to use the Rest API for listing Pull Requests as a workaround.