### PR TITLE
Run build jobs on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Node
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
If someone issues a PR from a fork, we don't run the build job, which then prevents deployment/merging.