### PR TITLE
Add a current command to stafftools

### DIFF
--- a/bin/stafftools
+++ b/bin/stafftools
@@ -162,7 +162,7 @@ class JiraStaffTools < Thor
       repos = JSON.parse(body)["repos"]
 
       current = repos.values.detect do |r|
-        [r["pullStatus"], r["branchStatus"], r["commitStatus"]] != (["complete"] * 3)
+        [r["pullStatus"], r["branchStatus"], r["commitStatus"]] != %w(completed completed completed)
       end
 
       if current

--- a/bin/stafftools
+++ b/bin/stafftools
@@ -26,7 +26,7 @@ class JiraStaffTools < Thor
     output_json(body)
   end
 
-  desc "status <git_hub_installation_id>", "Display repo sync status"
+  desc "status <git_hub_installation_id> [--current]", "Display repo sync status"
   option :current, type: :boolean, desc: "Show the current repo being synced"
   def status(git_hub_installation_id)
     jira_host = get_jira_host(git_hub_installation_id)
@@ -41,7 +41,7 @@ class JiraStaffTools < Thor
     end
   end
 
-  desc "sync <git_hub_installation_id>", "Trigger sync (defaults to 'normal')"
+  desc "sync <git_hub_installation_id> [--full]", "Trigger sync (defaults to 'normal')"
   option :reset, type: :boolean, desc: "Clear sync status and start from beginning ('full')"
   def sync(git_hub_installation_id)
     sync_type = "full" if options[:reset]

--- a/bin/stafftools
+++ b/bin/stafftools
@@ -45,26 +45,21 @@ class JiraStaffTools < Thor
       "jiraHost" => jira_host
     )
 
-    foundIt = false
     repos = JSON.parse(response.body)["repos"]
-    doneCount = 0
 
-    repos.each do |repo_id, r|
-      if [r["pullStatus"], r["branchStatus"], r["commitStatus"]] == (["complete"] * 3)
-        doneCount += 1
-        next
-      end
-
-      puts "Working on #{r["repository"]["owner"]["login"]}/#{r["repository"]["name"]}"
-      puts "\t*  pullStatus: #{r["pullStatus"]} @ #{r["lastPullCursor"]}" if r["pullStatus"]
-      puts "\t*  branchStatus: #{r["branchStatus"]} @ #{r["lastBranchCursor"]}" if r["branchStatus"]
-      puts "\t*  commitStatus: #{r["commitStatus"]} @ #{r["lastCommitCursor"]}" if r["commitStatus"]
-      puts "#{repos.length - doneCount} of #{repos.length} Repositories left to sync."
-      foundIt = true
-      break
+    current = repos.values.detect do |r|
+      [r["pullStatus"], r["branchStatus"], r["commitStatus"]] != (["complete"] * 3)
     end
 
-    puts "Did not find any item in progress" unless foundIt
+    if current
+      puts "Working on #{current["repository"]["owner"]["login"]}/#{current["repository"]["name"]}"
+      puts "\t*  pullStatus: #{current["pullStatus"]} @ #{current["lastPullCursor"]}" if current["pullStatus"]
+      puts "\t*  branchStatus: #{current["branchStatus"]} @ #{current["lastBranchCursor"]}" if current["branchStatus"]
+      puts "\t*  commitStatus: #{current["commitStatus"]} @ #{current["lastCommitCursor"]}" if current["commitStatus"]
+      puts "#{repos.length - repos.values.index(current)} of #{repos.length} Repositories left to sync."
+    else
+      puts "Did not find any item in progress"
+    end
   end
 
   desc "sync <git_hub_installation_id>", "Trigger sync (defaults to 'normal')"

--- a/bin/stafftools
+++ b/bin/stafftools
@@ -162,7 +162,7 @@ class JiraStaffTools < Thor
       repos = JSON.parse(body)["repos"]
 
       current = repos.values.detect do |r|
-        [r["pullStatus"], r["branchStatus"], r["commitStatus"]] != %w(completed completed completed)
+        [r["pullStatus"], r["branchStatus"], r["commitStatus"]] != %w(complete complete complete)
       end
 
       if current

--- a/bin/stafftools
+++ b/bin/stafftools
@@ -37,6 +37,36 @@ class JiraStaffTools < Thor
     output_json(response.body)
   end
 
+  desc "current <git_hub_installation_id>", "Display the current sync item"
+  def current(git_hub_installation_id)
+    jira_host = get_jira_host(git_hub_installation_id)
+    response = client.get(
+      "/api/#{CGI.escape(git_hub_installation_id)}/repoSyncState.json",
+      "jiraHost" => jira_host
+    )
+
+    foundIt = false
+    repos = JSON.parse(response.body)["repos"]
+    doneCount = 0
+
+    repos.each do |repo_id, r|
+      if [r["pullStatus"], r["branchStatus"], r["commitStatus"]] == (["complete"] * 3)
+        doneCount += 1
+        next
+      end
+
+      puts "Working on #{r["repository"]["owner"]["login"]}/#{r["repository"]["name"]}"
+      puts "\t*  pullStatus: #{r["pullStatus"]} @ #{r["lastPullCursor"]}" if r["pullStatus"]
+      puts "\t*  branchStatus: #{r["branchStatus"]} @ #{r["lastBranchCursor"]}" if r["branchStatus"]
+      puts "\t*  commitStatus: #{r["commitStatus"]} @ #{r["lastCommitCursor"]}" if r["commitStatus"]
+      puts "#{repos.length - doneCount} of #{repos.length} Repositories left to sync."
+      foundIt = true
+      break
+    end
+
+    puts "Did not find any item in progress" unless foundIt
+  end
+
   desc "sync <git_hub_installation_id>", "Trigger sync (defaults to 'normal')"
   option :reset, type: :boolean, desc: "Clear sync status and start from beginning ('full')"
   def sync(git_hub_installation_id)
@@ -51,7 +81,7 @@ class JiraStaffTools < Thor
 
     output_json(response.body)
   end
-  
+
   desc "migrate <git_hub_installation_id>", "Mark as migrated from DVCS and set sync to COMPLETE"
   def migrate(git_hub_installation_id)
     jira_host = get_jira_host(git_hub_installation_id)
@@ -74,7 +104,7 @@ class JiraStaffTools < Thor
   long_desc <<~DESC
     Trigger the same uninstall process that occurs when a customer
     uninstalls the GitHub for Jira Atlassian Marketplace app.
-    
+
     Note: this does not uninstall the app from a customer's Jira
           instance, it only removes the data from our side.
   DESC
@@ -120,13 +150,13 @@ class JiraStaffTools < Thor
       range: "7d".to_json,
       end: "null",
       limit: 1000,
-      start: "null", 
+      start: "null",
       utc: "null",
     }
 
     url = URI("https://sentry.io/organizations/github-integrations/discover")
     url.query = URI.encode_www_form(params)
-    
+
     `open #{url.to_s.shellescape}`
   end
 

--- a/bin/stafftools
+++ b/bin/stafftools
@@ -27,38 +27,17 @@ class JiraStaffTools < Thor
   end
 
   desc "status <git_hub_installation_id>", "Display repo sync status"
+  option :current, type: :boolean, desc: "Show the current repo being synced"
   def status(git_hub_installation_id)
     jira_host = get_jira_host(git_hub_installation_id)
     response = client.get(
       "/api/#{CGI.escape(git_hub_installation_id)}/repoSyncState.json",
       "jiraHost" => jira_host
     )
-
-    output_json(response.body)
-  end
-
-  desc "current <git_hub_installation_id>", "Display the current sync item"
-  def current(git_hub_installation_id)
-    jira_host = get_jira_host(git_hub_installation_id)
-    response = client.get(
-      "/api/#{CGI.escape(git_hub_installation_id)}/repoSyncState.json",
-      "jiraHost" => jira_host
-    )
-
-    repos = JSON.parse(response.body)["repos"]
-
-    current = repos.values.detect do |r|
-      [r["pullStatus"], r["branchStatus"], r["commitStatus"]] != (["complete"] * 3)
-    end
-
-    if current
-      puts "Working on #{current["repository"]["owner"]["login"]}/#{current["repository"]["name"]}"
-      puts "\t*  pullStatus: #{current["pullStatus"]} @ #{current["lastPullCursor"]}" if current["pullStatus"]
-      puts "\t*  branchStatus: #{current["branchStatus"]} @ #{current["lastBranchCursor"]}" if current["branchStatus"]
-      puts "\t*  commitStatus: #{current["commitStatus"]} @ #{current["lastCommitCursor"]}" if current["commitStatus"]
-      puts "#{repos.length - repos.values.index(current)} of #{repos.length} Repositories left to sync."
+    if options[:current]
+      status_current(response.body)
     else
-      puts "Did not find any item in progress"
+      output_json(response.body)
     end
   end
 
@@ -176,6 +155,24 @@ class JiraStaffTools < Thor
         puts out
       else
         puts JSON.pretty_generate(JSON.parse(json_string))
+      end
+    end
+
+    def status_current(body)
+      repos = JSON.parse(body)["repos"]
+
+      current = repos.values.detect do |r|
+        [r["pullStatus"], r["branchStatus"], r["commitStatus"]] != (["complete"] * 3)
+      end
+
+      if current
+        puts "Working on #{current["repository"]["owner"]["login"]}/#{current["repository"]["name"]}"
+        puts "\t*  pullStatus: #{current["pullStatus"]} @ #{current["lastPullCursor"]}" if current["pullStatus"]
+        puts "\t*  branchStatus: #{current["branchStatus"]} @ #{current["lastBranchCursor"]}" if current["branchStatus"]
+        puts "\t*  commitStatus: #{current["commitStatus"]} @ #{current["lastCommitCursor"]}" if current["commitStatus"]
+        puts "#{repos.length - repos.values.index(current)} of #{repos.length} Repositories left to sync."
+      else
+        puts "Did not find any item in progress"
       end
     end
   end


### PR DESCRIPTION
Frequently I find it's not enough to know if a sync is in progress while
debugging, I also often want to know where we are in the process
and how long we have left to go. Also being able to see that things are
changing is helpful to know that a sync is progressing. The new "current"
command shows the cursor for the fetch (if it changes, fetching is
progressing) and the total count of repositories left.