### PR TITLE
Remove unused nock calls and ensure we use proper access_tokens endpoint

### DIFF
--- a/test/setup/app.js
+++ b/test/setup/app.js
@@ -38,7 +38,7 @@ beforeEach(() => {
     });
 
   nock('https://api.github.com')
-    .post(/\/installations\/[\d\w-]+\/access_tokens/)
+    .post(/\/app\/installations\/[\d\w-]+\/access_tokens/)
     .reply(200, {
       token: 'mocked-token',
       expires_at: '9999-12-31T23:59:59Z',

--- a/test/unit/sync/branch.test.js
+++ b/test/unit/sync/branch.test.js
@@ -66,10 +66,6 @@ function makeExpectedResponse({ branchName }) {
 }
 
 function nockBranchRequst(payload) {
-  nock('https://api.github.com')
-    .post('/installations/1/access_tokens')
-    .reply(200, { token: '1234' });
-
   const { branchesNoLastCursor, branchesWithLastCursor } = require('../../fixtures/api/graphql/commit-queries');
   nock('https://api.github.com')
     .post('/graphql', branchesNoLastCursor)
@@ -128,10 +124,6 @@ describe('sync/branches', () => {
     const { processInstallation } = require('../../../lib/sync/installation');
 
     const job = createJob({ data: { installationId, jiraHost }, opts: { delay } });
-
-    nock('https://api.github.com')
-      .post('/installations/1/access_tokens')
-      .reply(200, { token: '1234' });
 
     const branchNodesFixture = require('../../fixtures/api/graphql/branch-ref-nodes.json');
     nockBranchRequst(branchNodesFixture);

--- a/test/unit/sync/commits.test.js
+++ b/test/unit/sync/commits.test.js
@@ -53,8 +53,6 @@ describe('sync/commits', () => {
 
     const job = createJob({ data: { installationId, jiraHost }, opts: { delay } });
 
-    nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
-
     const commitNodesFixture = require('../../fixtures/api/graphql/commit-nodes.json');
 
     const { commitsNoLastCursor, commitsWithLastCursor, getDefaultBranch } = require('../../fixtures/api/graphql/commit-queries');
@@ -111,8 +109,6 @@ describe('sync/commits', () => {
     const { processInstallation } = require('../../../lib/sync/installation');
 
     const job = createJob({ data: { installationId, jiraHost }, opts: { delay } });
-
-    nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
 
     const mixedCommitNodes = require('../../fixtures/api/graphql/commit-nodes-mixed.json');
 
@@ -205,8 +201,6 @@ describe('sync/commits', () => {
 
     const job = createJob({ data: { installationId, jiraHost }, opts: { delay } });
 
-    nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
-
     const commitNodesFixture = require('../../fixtures/api/graphql/commit-nodes.json');
     const defaultBranchNullFixture = require('../../fixtures/api/graphql/default-branch-null.json');
 
@@ -265,8 +259,6 @@ describe('sync/commits', () => {
 
     const job = createJob({ data: { installationId, jiraHost }, opts: { delay } });
 
-    nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
-
     const commitsNoKeys = require('../../fixtures/api/graphql/commit-nodes-no-keys.json');
 
     const { commitsNoLastCursor, commitsWithLastCursor, getDefaultBranch } = require('../../fixtures/api/graphql/commit-queries');
@@ -294,8 +286,6 @@ describe('sync/commits', () => {
     const { processInstallation } = require('../../../lib/sync/installation');
 
     const job = createJob({ data: { installationId, jiraHost } });
-
-    nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
 
     const { commitsNoLastCursor, commitsWithLastCursor, getDefaultBranch } = require('../../fixtures/api/graphql/commit-queries');
 

--- a/test/unit/sync/pull-requests.test.js
+++ b/test/unit/sync/pull-requests.test.js
@@ -49,8 +49,6 @@ describe('sync/pull-request', () => {
 
     const job = createJob({ data: { installationId, jiraHost } });
 
-    nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
-
     const pullRequestList = JSON.parse(JSON.stringify(require('../../fixtures/api/pull-request-list.json')));
     pullRequestList[0].title = '[TES-15] Evernote Test';
 
@@ -111,8 +109,6 @@ describe('sync/pull-request', () => {
 
     const job = createJob({ data: { installationId, jiraHost } });
 
-    nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
-
     nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls?per_page=20&page=1&state=all&sort=created&direction=desc')
       .reply(200, []);
 
@@ -135,8 +131,6 @@ describe('sync/pull-request', () => {
     const { processInstallation } = require('../../../lib/sync/installation');
     process.env.LIMITER_PER_INSTALLATION = 2000;
     const job = createJob({ data: { installationId, jiraHost }, opts: { delay: 2000 } });
-
-    nock('https://api.github.com').post('/installations/1/access_tokens').reply(200, { token: '1234' });
 
     const pullRequestList = JSON.parse(JSON.stringify(require('../../fixtures/api/pull-request-list.json')));
 


### PR DESCRIPTION
The old endpoint `/installations/:installation_id/access_tokens` is going away, and will have a brownout soon. Our tests were coded against this old endpoint, but it looks like Octokit saved us and was using the updated endpoint. Because of hte way test/setup/app.js was matching the installations endpoint (using a regex) the tests were still succeeding. We had a lot of tests that included a nock call to the old endpoint, these were never hit. We don't check to make sure all nock calls were fulfilled, so these were just taking up memory.