### PR TITLE
add reviewers to pull request

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -25,7 +25,7 @@ module.exports = (robot) => {
 
   robot.on('push', middleware(push));
 
-  robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited'], middleware(pullRequest));
+  robot.on(['pull_request.opened', 'pull_request.closed', 'pull_request.reopened', 'pull_request.edited', 'pull_request.review_requested', 'pull_request.review_request_removed'], middleware(pullRequest));
 
   robot.on('create', middleware(createBranch));
   robot.on('delete', middleware(deleteBranch));

--- a/lib/transforms/pull-request.js
+++ b/lib/transforms/pull-request.js
@@ -15,6 +15,22 @@ function mapStatus({ state, merged }) {
   }
 }
 
+function formatReviewers(reviewers, review) {
+  let formattedReviewers = [];
+
+  for (reviewer of reviewers) {
+    let formattedReviewer = {
+      name: reviewer.login,
+      url: reviewer.url,
+      avatar: reviewer.avatar_url,
+    };
+
+    formattedReviewers.push(formattedReviewer);
+  }
+
+  return formattedReviewers;
+}
+
 module.exports = (payload, author) => {
   // eslint-disable-next-line camelcase
   const { pull_request, repository } = payload;
@@ -73,6 +89,7 @@ module.exports = (payload, author) => {
           title: pull_request.title,
           url: pull_request.html_url,
           updateSequenceId: Date.now(),
+          reviewers: formatReviewers(pull_request.requested_reviewers),
         },
       ],
       updateSequenceId: Date.now(),


### PR DESCRIPTION
## What
This adds the reviewers from a pull request to the Jira payload so that the Jira development panel will now display the reviewers

<img width="441" alt="Screen Shot 2020-08-17 at 4 41 50 PM" src="https://user-images.githubusercontent.com/13006398/90454631-aeccb400-e0a8-11ea-91d4-34d6608c7087.png">

## Note
This change does not include tracking a reviewer's review state: `APPROVED`, `COMMENTED`, `REQUSTED_CHANGES`. I investigated including the `approvalStatus` with the Jira payload and determined that we'd need to persistently store each review's state. It'll take a bit more work, so I'm pushing up the changes to list the reviewers first. 