### PR TITLE
Bump connection pool to 15

### DIFF
--- a/db/config.json
+++ b/db/config.json
@@ -18,7 +18,7 @@
       "ssl": true
     },
     "pool": {
-      "max": 5
+      "max": 15
     }
   }
 }


### PR DESCRIPTION
We are bumping our connection pool to 15 due to an incident. 15 seems like the right number because we maxed out at 106 connections in the last 7 days, and our db plan allows us a max of 400.

Our theory is that all of the db connections are being used by background jobs so there might be too much waiting happening.