### PR TITLE
Make issue key parsing case insensitive

### DIFF
--- a/lib/smart-commit-tokenizer.js
+++ b/lib/smart-commit-tokenizer.js
@@ -3,7 +3,7 @@ const newrelic = require('newrelic');
 
 // RDVCS Connector regexp provided by Atlassian
 const punct = '!"\\#$%&\'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~';
-const issueKeysRegex = new RegExp(`(?:(?<=[\\s${punct}])|^)(?:[A-Z][A-Z\\d]+-\\d+)(?:(?=[\\s${punct}])|$)`);
+const issueKeysRegex = new RegExp(`(?:(?<=[\\s${punct}])|^)(?:[A-Za-z][A-Za-z\\d]+-\\d+)(?:(?=[\\s${punct}])|$)`);
 
 module.exports = function () {
   const transition = { match: /(?<= )#[a-z-]+?(?:(?= )|$)/, value: text => text.slice(1), push: 'transition' };
@@ -16,7 +16,10 @@ module.exports = function () {
   return newrelic.startSegment('smart-commit-tokenizer', true,
     () => moo.states({
       main: {
-        issueKey: issueKeysRegex,
+        issueKey: {
+          match: issueKeysRegex,
+          value: s => s.toUpperCase(),
+        },
         time,
         transition,
         whitespace,

--- a/test/unit/smart-commit.test.js
+++ b/test/unit/smart-commit.test.js
@@ -138,6 +138,16 @@ describe('Smart commit parsing', () => {
       });
     });
 
+    it('should parse an issue key, case insensitively, and transform it to uppercase', () => {
+      const text = 'jra-090';
+
+      const result = smartCommit(text);
+
+      expect(result).toEqual({
+        issueKeys: ['JRA-090'],
+      });
+    });
+
     it('should not parse an issue key with an underscore and numbers', () => {
       const text = 'J_1993A-090 J_1993A-090';
 


### PR DESCRIPTION
This modifies the issue key regex to match lowercase characters.

In addition it adds a transform to the moo.js issue key tokenizer to maintain the same all caps output in the event that anything Jira side is case sensitive (though I don't believe it is).

I also added a lowercase test.