### PR TITLE
Use express-rate-limiter for rate limiting

### DIFF
--- a/lib/config/cidr-validator.js
+++ b/lib/config/cidr-validator.js
@@ -1,0 +1,60 @@
+const newrelic = require('newrelic');
+
+/**
+ * The following IP/CIDR functions adapted from a blog post
+ *
+ * [MyBuilder.com]{@link https://tech.mybuilder.com/determining-if-an-ipv4-address-is-within-a-cidr-range-in-javascript/}
+ */
+
+/* eslint no-bitwise: ["error", { "allow": ["<<", ">>>", "~", "&"] }] */
+/**
+ * Convert an IP to an integer
+ *
+ * @param {string} ip - The IP to convert to an integer
+ * @returns {number} Integer representation of the IP Address
+ */
+function ip4ToInt(ip) {
+  return ip.split('.').reduce((int, oct) => (int << 8) + parseInt(oct, 10), 0) >>> 0;
+}
+
+/**
+ * Wrapper function to keep the IP in scope while we test the CIDRs
+ *
+ * @param {string} ip - The IP Address in question
+ * @returns {Function} A function to compare an IP to the CIDR
+ */
+function isIp4InCidr(ip) {
+  const intIP = ip4ToInt(ip);
+  /**
+   * Take a CIDR and return if the IP Address in scope matches
+   *
+   * @param {string} cidr - The CIDR to compare with
+   * @returns {boolean} if the IP is in the CIDR
+   */
+  return function (cidr) {
+    // Trace this function to ensure it's not extraordinarily expensive
+    return newrelic.startSegment('isIp4InCidr', true, () => {
+      const [range, bits = 32] = cidr.split('/');
+      const mask = ~(2 ** (32 - bits) - 1);
+      return (intIP & mask) === (ip4ToInt(range) & mask);
+    });
+  };
+}
+
+/**
+ * Determine if an IPv4 Address is within a list of CIDRs
+ *
+ * @param {string} ip - The IP Address in Question
+ * @param {string[]} cidrs - The list of CIDRs applicable
+ * @returns {boolean} if the IP is in any of the CIDRs
+ * @example
+ * > isIp4InCidrs('192.168.1.5', ['10.10.0.0/16', '192.168.1.1/24']);
+ * true
+ */
+function isIp4InCidrs(ip, cidrs) {
+  return cidrs.some(isIp4InCidr(ip));
+}
+
+module.exports = {
+  isIp4InCidrs,
+};

--- a/lib/configure-robot.js
+++ b/lib/configure-robot.js
@@ -51,7 +51,7 @@ async function getGitHubCIDRs(logger) {
   });
   const metaResp = await api.meta.get();
   const GitHubCIDRs = metaResp.data.hooks;
-  logger.info({ GitHubCIDRs }, 'Whitelisted CIDRs for rate limiting');
+  logger.info({ GitHubCIDRs }, 'CIDRs that can skip rate limiting');
   return GitHubCIDRs;
 }
 
@@ -73,7 +73,7 @@ module.exports = async (app) => {
        * NOTE: This is only expected to be done for IP CIDRs we trust (github)
        *
        * @param {import('express').Request} req
-       * @returns {boolean} if the IP is within our whitelisted cidrs
+       * @returns {boolean} if the IP is within our non-rate-limited cidrs
        */
       skip(req) {
         return isIp4InCidrs(req.ip, GitHubCIDRs);

--- a/lib/configure-robot.js
+++ b/lib/configure-robot.js
@@ -60,39 +60,41 @@ async function getGitHubCIDRs(logger) {
  * @param {import('probot').Application} app - The probot application
  */
 module.exports = async (app) => {
-  const GitHubCIDRs = getGitHubCIDRs(app.log);
-  const client = new Redis(getRedisInfo('rate-limiter').redisOptions);
-  const limiter = new RateLimit({
-    store: new RedisStore({
-      client,
-    }),
-    /**
-     * Check if we should skip rate limiting
-     *
-     * NOTE: This is only expected to be done for IP CIDRs we trust (github)
-     *
-     * @param {import('express').Request} req
-     * @returns {boolean} if the IP is within our whitelisted cidrs
-     */
-    skip(req) {
-      return isIp4InCidrs(req.ip, GitHubCIDRs);
-    },
-    /**
-     * Handle when a users hits the rate limit
-     *
-     * @param {import('express').Request} req
-     * @param {import('express').Response} res
-     */
-    handler(req, res) {
-      // We don't include path in this metric as the bots scanning us generate many of them
-      statsd.increment('express.rate_limited');
-      res.status(429).send('Too many requests, please try again later.');
-    },
-    max: 100, // limit each IP to a number of requests per windowMs
-    delayMs: 0, // disable delaying - full speed until the max limit is reached
-  });
+  if (process.env.USE_RATE_LIMITING === 'true') {
+    const GitHubCIDRs = await getGitHubCIDRs(app.log);
+    const client = new Redis(getRedisInfo('rate-limiter').redisOptions);
+    const limiter = new RateLimit({
+      store: new RedisStore({
+        client,
+      }),
+      /**
+       * Check if we should skip rate limiting
+       *
+       * NOTE: This is only expected to be done for IP CIDRs we trust (github)
+       *
+       * @param {import('express').Request} req
+       * @returns {boolean} if the IP is within our whitelisted cidrs
+       */
+      skip(req) {
+        return isIp4InCidrs(req.ip, GitHubCIDRs);
+      },
+      /**
+       * Handle when a users hits the rate limit
+       *
+       * @param {import('express').Request} req
+       * @param {import('express').Response} res
+       */
+      handler(req, res) {
+        // We don't include path in this metric as the bots scanning us generate many of them
+        statsd.increment('express.rate_limited');
+        res.status(429).send('Too many requests, please try again later.');
+      },
+      max: 100, // limit each IP to a number of requests per windowMs
+      delayMs: 0, // disable delaying - full speed until the max limit is reached
+    });
 
-  app.router.use(limiter);
+    app.router.use(limiter);
+  }
 
   // These incoming webhooks should skip rate limiting
   setupGitHub(app);

--- a/lib/configure-robot.js
+++ b/lib/configure-robot.js
@@ -1,16 +1,106 @@
+const Redis = require('ioredis');
+const RateLimit = require('express-rate-limit');
+const RedisStore = require('rate-limit-redis');
+
+const { GitHubAPI } = require('probot');
+const { createAppAuth } = require('@octokit/auth-app');
+
+const { findPrivateKey } = require('probot/lib/private-key');
+
+const getRedisInfo = require('./config/redis-info');
 const setupFrontend = require('./frontend');
 const setupGitHub = require('./github');
 const setupJira = require('./jira');
 const setupPing = require('./ping');
+const statsd = require('./config/statsd');
+const { isIp4InCidrs } = require('./config/cidr-validator');
+
+/**
+ * Get the list of GitHub CIDRs from the /meta endpoint
+ *
+ * This is a weird one, the /meta endpoint has a very small rate limit
+ * for non-authed users, but also doesn't allow queries from authenticated
+ * apps, it must be from an installation of an application. So we fetch
+ * the first installation and query as it. It only happens on boot, and
+ * shouldn't affect anything else, it's theoretically safe.
+ *
+ * @param {import('probot').Logger} logger - The Application's logger
+ * @returns {string[]} A list of CIDRs for GitHub webhooks
+ */
+async function getGitHubCIDRs(logger) {
+  let api = GitHubAPI({
+    authStrategy: createAppAuth,
+    auth: {
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      id: process.env.APP_ID,
+      privateKey: findPrivateKey(),
+    },
+    logger,
+  });
+  const inst = await api.apps.listInstallations({
+    per_page: 1,
+  });
+  const { token } = await api.auth({
+    type: 'installation',
+    installationId: inst.data[0].id,
+  });
+  api = GitHubAPI({
+    auth: token,
+    logger,
+  });
+  const metaResp = await api.meta.get();
+  const GitHubCIDRs = metaResp.data.hooks;
+  logger.info({ GitHubCIDRs }, 'Whitelisted CIDRs for rate limiting');
+  return GitHubCIDRs;
+}
 
 /**
  *
  * @param {import('probot').Application} app - The probot application
  */
-module.exports = (app) => {
-  setupFrontend(app);
+module.exports = async (app) => {
+  const GitHubCIDRs = getGitHubCIDRs(app.log);
+  const client = new Redis(getRedisInfo('rate-limiter').redisOptions);
+  const limiter = new RateLimit({
+    store: new RedisStore({
+      client,
+    }),
+    /**
+     * Check if we should skip rate limiting
+     *
+     * NOTE: This is only expected to be done for IP CIDRs we trust (github)
+     *
+     * @param {import('express').Request} req
+     * @returns {boolean} if the IP is within our whitelisted cidrs
+     */
+    skip(req) {
+      return isIp4InCidrs(req.ip, GitHubCIDRs);
+    },
+    /**
+     * Handle when a users hits the rate limit
+     *
+     * @param {import('express').Request} req
+     * @param {import('express').Response} res
+     */
+    handler(req, res) {
+      // We don't include path in this metric as the bots scanning us generate many of them
+      statsd.increment('express.rate_limited');
+      res.status(429).send('Too many requests, please try again later.');
+    },
+    max: 100, // limit each IP to a number of requests per windowMs
+    delayMs: 0, // disable delaying - full speed until the max limit is reached
+  });
+
+  app.router.use(limiter);
+
+  // These incoming webhooks should skip rate limiting
   setupGitHub(app);
+  // According to NewRelic, we receive < 1 request per minute from Jira
   setupJira(app);
+  // Our FrontEnd Assets are between 1 and 4 RPM
+  setupFrontend(app);
+  // Opaque is expected to query us twice per minute
   setupPing(app);
 
   return app;

--- a/lib/run.js
+++ b/lib/run.js
@@ -27,6 +27,8 @@ const probot = createProbot({
  * Start the probot worker.
  */
 function start() {
+  // We are always behind a proxy, but we want the source IP
+  probot.server.set('trust proxy', true);
   probot.load(app);
   probot.start();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1650,6 +1650,48 @@
         }
       }
     },
+    "@octokit/auth-app": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-2.6.0.tgz",
+      "integrity": "sha512-hw8jm4N+1KENpyjXHu1epAOc5BjMAY9yW2LZ9DhgZ8QtXcU7JZaccMk0/C/71zKq1dczw9O1McBmbViZc9/u8w==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "universal-github-app-jwt": "^1.0.1",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/types": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+          "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+          "requires": {
+            "@types/node": ">= 8"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "universal-user-agent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+          "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "@octokit/auth-token": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
@@ -2193,6 +2235,19 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "@types/jsonwebtoken": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+      "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/lru-cache": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.0.tgz",
+      "integrity": "sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w=="
     },
     "@types/node": {
       "version": "10.3.3",
@@ -12741,6 +12796,15 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universal-github-app-jwt": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.1.0.tgz",
+      "integrity": "sha512-3b+ocAjjz4JTyqaOT+NNBd5BtTuvJTxWElIoeHSVelUV9J3Jp7avmQTdLKCaoqi/5Ox2o/q+VK19TJ233rVXVQ==",
+      "requires": {
+        "@types/jsonwebtoken": "^8.3.3",
+        "jsonwebtoken": "^8.5.1"
       }
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@atlaskit/css-reset": "^2.0.5",
     "@atlaskit/reduced-ui-pack": "^8.19.0",
+    "@octokit/auth-app": "^2.6.0",
     "@sentry/integrations": "^5.15.5",
     "@sentry/node": "^5.15.5",
     "atlassian-jwt": "^0.1.5",

--- a/test/setup/app.js
+++ b/test/setup/app.js
@@ -3,7 +3,7 @@ const { findPrivateKey } = require('probot/lib/private-key');
 const cacheManager = require('cache-manager');
 const { App } = require('@octokit/app');
 
-beforeEach(() => {
+beforeEach(async () => {
   const models = td.replace('../../lib/models', {
     Installation: td.object(['getForHost', 'findByPk']),
     Subscription: td.object([
@@ -50,7 +50,7 @@ beforeEach(() => {
 
   const configureRobot = require('../../lib/configure-robot');
 
-  global.app = configureRobot(new Application({
+  global.app = await configureRobot(new Application({
     app: new App({
       id: 12257,
       privateKey: findPrivateKey(),

--- a/test/unit/config/cidr-validator.test.js
+++ b/test/unit/config/cidr-validator.test.js
@@ -1,0 +1,12 @@
+const { isIp4InCidrs } = require('../../../lib/config/cidr-validator');
+
+describe('cidr-validator', () => {
+  test.each([
+    ['192.168.1.5', ['10.10.0.0/16', '192.168.1.1/24'], true],
+    ['10.10.1.5', ['10.10.0.0/16', '192.168.1.1/24'], true],
+    ['122.168.1.5', ['10.10.0.0/16', '192.168.1.1/24'], false],
+    ['some-hostname', ['10.10.0.0/16', '192.168.1.1/24'], false],
+  ])('.isIp4InCidrs(%p, %p) === %p', (ip, cidrs, expected) => {
+    expect(isIp4InCidrs(ip, cidrs)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Recently we've been having issues with malicious users scanning looking for random files on the jira application, this causes us to exceed our SLOs and to fail to process a lot of valid requests. This PR adds [express-rate-limiter](https://github.com/nfriedly/express-rate-limit) to try to alleviate those problems.

To avoid rate limiting incoming requests from webhooks, we query the [GitHub Meta Endpoint](https://docs.github.com/en/free-pro-team@latest/rest/reference/meta#get-github-meta-information) to get a list of the current webhook CIDRs. These should not change frequently, so fetching them on startup seems reasonable. Based on our incoming query volume from things other than github webhooks, we do not see anything greater than 5 requests per minute as an average, I've set the max to 100 just to give busy users plenty of room.

These rate limits are coordinated through our Redis instance, so even when incoming requests are balanced across the workers, we should still benefit from the load balancing.

There is a new feature flag (as an env var): `USE_RATE_LIMITING` must be `'true'` to enable this rate limiting, otherwise the app should perform as it did before.

There are new metrics:
`jira_integration.express.rate_limited` will show up in datadog counting the number of times we've rate limited requests, this will need to be monitored when the flag is enabled.

Additionally there is a newrelic tracing segment named `isIp4InCidr` which should let us know how efficient (in practice) the CIDR validation function is, it appears to be very quick, but it's good to see it under load as well.