### PR TITLE
Include logMiddleware to avoid lifecycle event failures

### DIFF
--- a/lib/jira/index.js
+++ b/lib/jira/index.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 
 const { Installation } = require('../models');
 const { hasValidJwt } = require('./util/jwt');
+const logMiddleware = require('../middleware/log-middleware');
 
 const connect = require('./connect');
 const disable = require('./disable');
@@ -33,6 +34,7 @@ module.exports = (robot) => {
   // The request handler must be the first middleware on the app
   router.use(Sentry.Handlers.requestHandler());
   router.use(bodyParser.json());
+  router.use(logMiddleware);
 
   // Set up event handlers
   router.get('/atlassian-connect.json', connect);


### PR DESCRIPTION
Starting yesterday (2020-10-08T13:59:14.144355+00:00) a new error started occuring related to lifecycle events. Specifically the `addLogFields` middleware wasn't included, so these routes started failing. 

Somehow the rate limiting PR seems to have introduced this issue.

Related Sentry Error: 
https://sentry.io/organizations/github-integrations/issues/1944394118/?project=1240711&query=is%3Aunresolved&statsPeriod=24h