### PR TITLE
Use a unified JiraClientError message

### DIFF
--- a/lib/jira/client/jira-client-error.js
+++ b/lib/jira/client/jira-client-error.js
@@ -3,9 +3,7 @@
  */
 class JiraClientError extends Error {
   constructor(error) {
-    const { status, statusText } = error.response;
-    const { method, path } = error.response.request;
-    const message = `${method} ${path} responded with ${status} ${statusText}`;
+    const message = 'Error communicating with Jira DevInfo API';
 
     super(message);
 


### PR DESCRIPTION
Because Sentry aggregates based on the message field of an error, we shouldn't
have this have a very high cardinality. The details are available in the
"request" and "response" fields in the Sentry Metadata

Example sentry event with request/response data in it https://sentry.io/organizations/github-integrations/issues/1946869803/?project=1240711&query=is%3Aunresolved&statsPeriod=1h