### PR TITLE
Check the HEAD ref for Jira IDs when syncing

### DIFF
--- a/lib/sync/transforms/pull-request.js
+++ b/lib/sync/transforms/pull-request.js
@@ -46,7 +46,8 @@ function getAuthor(author) {
  */
 module.exports = async (payload, author, github) => {
   const { pullRequest, repository } = payload;
-  const { issueKeys } = parseSmartCommit(pullRequest.title);
+  // This is the same thing we do in transforms, concat'ing these values
+  const { issueKeys } = parseSmartCommit(`${pullRequest.title}\n${pullRequest.head.ref}`);
 
   if (!issueKeys) {
     return {};

--- a/lib/transforms/pull-request.js
+++ b/lib/transforms/pull-request.js
@@ -18,6 +18,7 @@ function mapStatus({ state, merged }) {
 module.exports = (payload, author) => {
   // eslint-disable-next-line camelcase
   const { pull_request, repository } = payload;
+  // This is the same thing we do in sync, concat'ing these values
   const { issueKeys } = parseSmartCommit(`${pull_request.title}\n${pull_request.head.ref}`);
 
   if (!issueKeys || !pull_request.head.repo) {

--- a/test/unit/sync/pull-requests.test.js
+++ b/test/unit/sync/pull-requests.test.js
@@ -44,64 +44,70 @@ describe('sync/pull-request', () => {
       });
   });
 
-  test('should sync to Jira when Pull Request Nodes have jira references', async () => {
-    const { processInstallation } = require('../../../lib/sync/installation');
+  describe.each([
+    ['[TES-15] Evernote Test', 'use-the-force'],
+    ['Evernote Test', 'TES-15'],
+  ])('PR Title: %p, PR Head Ref: %p', (title, head) => {
+    test('should sync to Jira when Pull Request Nodes have jira references', async () => {
+      const { processInstallation } = require('../../../lib/sync/installation');
 
-    const job = createJob({ data: { installationId, jiraHost } });
+      const job = createJob({ data: { installationId, jiraHost } });
 
-    const pullRequestList = JSON.parse(JSON.stringify(require('../../fixtures/api/pull-request-list.json')));
-    pullRequestList[0].title = '[TES-15] Evernote Test';
+      const pullRequestList = JSON.parse(JSON.stringify(require('../../fixtures/api/pull-request-list.json')));
+      pullRequestList[0].title = title;
+      pullRequestList[0].head.ref = head;
 
-    // GET /repos/:owner/:repo/pulls
-    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls?per_page=20&page=1&state=all&sort=created&direction=desc')
-      .reply(200, pullRequestList);
-    nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls/51')
-      .reply(200, { comments: 0 });
+      // GET /repos/:owner/:repo/pulls
+      nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls?per_page=20&page=1&state=all&sort=created&direction=desc')
+        .reply(200, pullRequestList);
+      nock('https://api.github.com').get('/repos/integrations/test-repo-name/pulls/51')
+        .reply(200, { comments: 0 });
 
 
-    const queues = {
-      installation: {
-        add: jest.fn(),
-      },
-      pullRequests: {
-        add: jest.fn(),
-      },
-    };
-    await processInstallation(app, queues)(job);
-
-    td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
-      preventTransitions: true,
-      repositories: [
-        {
-          id: 'test-repo-id',
-          pullRequests: [
-            {
-              author: {
-                avatar: 'https://avatars0.githubusercontent.com/u/173?v=4',
-                name: 'bkeepers',
-                url: 'https://api.github.com/users/bkeepers',
-              },
-              commentCount: 0,
-              destinationBranch: 'test-repo-url/tree/devel',
-              displayId: '#51',
-              id: 51,
-              issueKeys: ['TES-15'],
-              lastUpdate: '2018-05-04T14:06:56Z',
-              sourceBranch: 'use-the-force',
-              sourceBranchUrl: 'test-repo-url/tree/use-the-force',
-              status: 'DECLINED',
-              timestamp: '2018-05-04T14:06:56Z',
-              title: '[TES-15] Evernote Test',
-              url: 'https://github.com/integrations/test/pull/51',
-              updateSequenceId: 12345678,
-            },
-          ],
-          url: 'test-repo-url',
-          updateSequenceId: 12345678,
+      const queues = {
+        installation: {
+          add: jest.fn(),
         },
-      ],
-      properties: { installationId: 1234 },
-    }));
+        pullRequests: {
+          add: jest.fn(),
+        },
+      };
+      await processInstallation(app, queues)(job);
+
+      td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
+        preventTransitions: true,
+        repositories: [
+          {
+            id: 'test-repo-id',
+            pullRequests: [
+              {
+                author: {
+                  avatar: 'https://avatars0.githubusercontent.com/u/173?v=4',
+                  name: 'bkeepers',
+                  url: 'https://api.github.com/users/bkeepers',
+                },
+                commentCount: 0,
+                destinationBranch: 'test-repo-url/tree/devel',
+                displayId: '#51',
+                id: 51,
+                issueKeys: ['TES-15'],
+                lastUpdate: '2018-05-04T14:06:56Z',
+                sourceBranch: head,
+                sourceBranchUrl: `test-repo-url/tree/${head}`,
+                status: 'DECLINED',
+                timestamp: '2018-05-04T14:06:56Z',
+                title,
+                url: 'https://github.com/integrations/test/pull/51',
+                updateSequenceId: 12345678,
+              },
+            ],
+            url: 'test-repo-url',
+            updateSequenceId: 12345678,
+          },
+        ],
+        properties: { installationId: 1234 },
+      }));
+    });
   });
 
   test('should not sync if nodes are empty', async () => {


### PR DESCRIPTION
A user noticed that when re-running a full sync, some PRs weren't updated. I believe this is due to a difference between how Webhooks and Full Syncs are handled. Webhooks would concatenate the head ref with the title to find Jira Issue Keys, but the full sync was only using the PR title. This updates them to have the same functionality, note that each is a copy of the other in a comment, and add a test to catch this to try to prevent a regression.