### PR TITLE
Build out framework for sending hydro events

### DIFF
--- a/lib/config/statsd.js
+++ b/lib/config/statsd.js
@@ -1,8 +1,54 @@
+const process = require('process');
 const StatsD = require('hot-shots');
 
 /** @type {import('hot-shots').StatsD} */
-module.exports = new StatsD({
+const statsd = new StatsD({
   prefix: 'jira-integration.',
   mock: process.env.NODE_ENV === 'test',
   globalTags: { env: process.env.NODE_ENV || 'unknown' },
 });
+
+/**
+ * High-resolution timer
+ *
+ * @returns {function(): number} A function to call to get the duration since this function was created
+ */
+function hrtimer() {
+  const start = process.hrtime();
+
+  /**
+   * hrtimer internal function
+   *
+   * @returns {number} The time since this callback was created
+   */
+  const inner = () => {
+    const durationComponents = process.hrtime(start);
+    const seconds = durationComponents[0];
+    const nanoseconds = durationComponents[1];
+    const duration = (seconds * 1000) + (nanoseconds / 1E6);
+    return duration;
+  };
+  return inner;
+}
+
+/**
+ * Async Function Timer using Distributions
+ *
+ * @param {Function} func - The function to time
+ * @param {string|Array<string>} stat - The stat name to record
+ * @param {number} [sampleRate] - The Rate to sample the metric
+ * @param {Array<string>} [tags] - Tags to add to the metric
+ * @param {import('hot-shots').StatsCb} [callback] - A callback when the function is complete
+ * @returns {Function} A function that you can call with your normal args that times your original function
+ */
+function asyncDistTimer(func, stat, sampleRate, tags, callback) {
+  return (...args) => {
+    const end = hrtimer();
+    const p = func(...args);
+    const recordStat = () => statsd.distribution(stat, end(), sampleRate, tags, callback);
+    p.then(recordStat, recordStat);
+    return p;
+  };
+}
+module.exports = statsd;
+module.exports.asyncDistTimer = asyncDistTimer;

--- a/lib/proto/v0/action.js
+++ b/lib/proto/v0/action.js
@@ -1,0 +1,91 @@
+/* eslint-disable no-unused-expressions */
+
+/**
+ * Enum for Action Proto Types
+ *
+ * @readonly
+ * @enum {string}
+ */
+const ActionType = {
+  CREATED: 'created',
+  DISABLED: 'disabled',
+  DESTROYED: 'destroyed',
+};
+
+/**
+ * Enum for Association Types
+ *
+ * @readonly
+ * @enum {string}
+ */
+const Association = {
+  SUBSCRIPTION: 'subscription',
+  INSTALLATION: 'installation',
+};
+
+/**
+ * Enum for Action Sources
+ *
+ * @readonly
+ * @enum {string}
+ */
+const ActionSource = {
+  /** An action that came from the Web UI Console in Jira */
+  WEB_CONSOLE: 'web_console',
+
+  /** An action from the Stafftools Script */
+  STAFFTOOLS: 'stafftools',
+
+  /** An action from a Jira Webhook */
+  WEBHOOK: 'webhook',
+};
+
+/**
+ * @typedef BaseProtobuf
+ * @property {string} schema
+ */
+
+/**
+ * Track an action on a subscription/installation
+ *
+ * Maps to the jira.v0.Action schema in github/hydro-schemas
+ *
+ * Must be updated manually when the hydro-schemas change.
+ *
+ * @implements {BaseProtobuf}
+ */
+class Action {
+  constructor() {
+    /** @type {ActionType} */
+    this.type;
+
+    /** @type {Association} */
+    this.association;
+
+    /** @type {?number} */
+    this.installationId;
+
+    /** @type {?number} */
+    this.githubInstallationId;
+
+    /** @type {?string} */
+    this.jiraHostname;
+
+    /** @type {ActionSource} */
+    this.actionSource;
+
+    /** @type {?number} */
+    this.githubActorId;
+  }
+
+  get schema() {
+    return 'jira.v0.Action';
+  }
+}
+
+module.exports = {
+  Action,
+  ActionType,
+  Association,
+  ActionSource,
+};

--- a/lib/tracking/index.js
+++ b/lib/tracking/index.js
@@ -72,7 +72,11 @@ async function submitProto(proto) {
     return true;
   }
   const data = {
-    events: [{ schema: proto.schema, value: JSON.stringify(proto) }],
+    events: [{
+      schema: proto.schema,
+      value: JSON.stringify(proto),
+      cluster: 'potomac',
+    }],
   };
 
   const dataStr = JSON.stringify(data);
@@ -88,7 +92,12 @@ async function submitProto(proto) {
       axiosInstance.post(
         BaseURL,
         dataStr,
-        { headers: { Authorization: `Hydro ${hmac.digest('hex')}` } },
+        {
+          headers: {
+            Authorization: `Hydro ${hmac.digest('hex')}`,
+            'Content-Type': 'application/json',
+          },
+        },
       );
     resp = await asyncDistTimer(axiosPost, postMetricName)();
     status = resp.status;

--- a/lib/tracking/index.js
+++ b/lib/tracking/index.js
@@ -1,0 +1,133 @@
+const process = require('process');
+const https = require('https');
+const { default: axios } = require('axios');
+const crypto = require('crypto');
+
+const { logger } = require('probot/lib/logger');
+const statsd = require('../config/statsd');
+const { asyncDistTimer } = require('../config/statsd');
+
+const BaseURL = process.env.HYDRO_BASE_URL;
+
+const axiosInstance = axios.create({
+  // Set a short timeout, this are disposable
+  timeout: 500,
+  httpsAgent: new https.Agent({
+    keepAlive: true,
+  }),
+});
+axiosInstance.defaults.headers.common['X-Hydro-App'] = 'jira-integration';
+
+const submissionMetricName = 'hydro.submission';
+const postMetricName = 'hydro.dist.post';
+const logErrStatuses = {
+  400: 'Hydro Missing clientID Header',
+  404: 'Hydro Unknown Schema',
+  422: 'Hydro Invalid Payload',
+  failure: 'Unable to connect to hydro to submit',
+};
+let disabled = ['true', '1'].includes(process.env.TRACKING_DISABLED);
+
+if (BaseURL == null) {
+  disabled = true;
+  logger.warn('No Hydro Base URL set, disabling tracking');
+}
+
+/**
+ * Ability to turn tracking on/off.
+ *
+ * @param {boolean} state - If the tracking should be disabled or not
+ * @returns {void}
+ */
+function setIsDisabled(state) {
+  disabled = state;
+}
+
+/**
+ * Return if tracking is disabled or not.
+ *
+ * @returns {boolean} If tracking is disabled
+ */
+function isDisabled() {
+  return disabled;
+}
+
+/**
+ * Submit Events to the HTTP Gateway
+ *
+ * @param {import('../proto/v0/action').BaseProtobuf} proto - The protobuf we want to submit
+ * @returns {Promise<boolean>} A promise that when resolved indicates if the submission was received successfully
+ *
+ * @example
+ * ```
+ * const data = new Action();
+ * action.type = ActionType.CREATED;
+ * action.association = Association.SUBSCRIPTION;
+ * action.actionSource = ActionSource.WEBHOOK;
+ * await submitProto(data);
+ * ```
+ */
+async function submitProto(proto) {
+  if (disabled) {
+    return true;
+  }
+  const data = {
+    events: [{ schema: proto.schema, value: JSON.stringify(proto) }],
+  };
+
+  const dataStr = JSON.stringify(data);
+  const hmac = crypto.createHmac('sha256', process.env.HYDRO_APP_SECRET || '');
+  hmac.update(dataStr);
+
+  /** @type {import('axios').AxiosResponse} */
+  let resp;
+  /** @type {number|string} */
+  let status;
+  try {
+    const axiosPost = async () =>
+      axiosInstance.post(
+        BaseURL,
+        dataStr,
+        { headers: { Authorization: `Hydro ${hmac.digest('hex')}` } },
+      );
+    resp = await asyncDistTimer(axiosPost, postMetricName)();
+    status = resp.status;
+    logger.debug('Hydro Protobuf Accepted', data);
+  } catch (err) {
+    if (err.response == null) {
+      // This is not an AxiosError
+      logger.error(err);
+      status = 'exception';
+    } else {
+      /** @type {import('axios').AxiosError} */
+      const axError = err;
+      /** @type {any} - The response data */
+      let respData;
+
+      resp = axError.response;
+      if (resp == null || resp.status == null) {
+        status = 'conn_failure';
+      } else {
+        status = resp.status;
+        respData = resp.data;
+      }
+
+      if (status in logErrStatuses) {
+        logger.error(logErrStatuses[status], { status, resp: respData, data });
+      } else {
+        logger.error('Hydro Submission Issue', { status, resp: respData, data });
+      }
+    }
+  }
+
+  statsd.increment(submissionMetricName, [`schema:${proto.schema}`, `status:${status}`]);
+
+  return status === 200;
+}
+
+module.exports = {
+  submitProto,
+  setIsDisabled,
+  isDisabled,
+  BaseURL,
+};

--- a/test/setup/env.js
+++ b/test/setup/env.js
@@ -4,7 +4,10 @@ const defaults = Object.assign({
   NODE_ENV: 'test',
   APP_URL: 'https://test-github-app-instance.com',
   ATLASSIAN_URL: 'https://test-atlassian-instance.net',
+  HYDRO_BASE_URL: 'https://hydro-base-url.com/api/v1/events',
   ATLASSIAN_SECRET: 'test-secret',
+  // Generated for tests
+  HYDRO_APP_SECRET: '2dd220c366ec5b86104efd7324c2d405',
   PRIVATE_KEY_PATH: './test/setup/test-key.pem',
   GITHUB_CLIENT_SECRET: 'test-github-secret',
   LOG_LEVEL: 'fatal',

--- a/test/unit/tracking.test.js
+++ b/test/unit/tracking.test.js
@@ -36,6 +36,7 @@ describe('Hydro Gateway Protobuf Submissions', () => {
     nock(basePath)
       .post(parsedURL.path)
       .reply(status, function (uri, requestBody) {
+        expect(this.req.headers['x-hydro-app']).toBe('jira-integration');
         const hmac = crypto.createHmac('sha256', AppSecret);
         hmac.update(requestBody.toString());
         expect(this.req.headers.authorization).toBe(`Hydro ${hmac.digest('hex')}`);

--- a/test/unit/tracking.test.js
+++ b/test/unit/tracking.test.js
@@ -1,0 +1,56 @@
+const url = require('url');
+const nock = require('nock');
+const crypto = require('crypto');
+
+const {
+  submitProto,
+  isDisabled,
+  setIsDisabled,
+  BaseURL,
+} = require('../../lib/tracking');
+
+const { Action, ActionType } = require('../../lib/proto/v0/action');
+
+const parsedURL = url.parse(BaseURL);
+const basePath = parsedURL.href.replace(parsedURL.path, '');
+const origDisabledState = isDisabled();
+const AppSecret = process.env.HYDRO_APP_SECRET;
+
+beforeAll(() => {
+  setIsDisabled(false);
+});
+
+afterAll(() => {
+  setIsDisabled(origDisabledState);
+});
+
+describe('Hydro Gateway Protobuf Submissions', () => {
+  test.each([
+    [200, true, 'OK'],
+    [400, false, 'clientID Missing'],
+    [404, false, 'Unknown schema'],
+    [422, false, 'Invalid Payload'],
+  ])('Protobuf submission status=%i expected=%p', async (status, expected, errMsg) => {
+    const e = new Action();
+    e.type = ActionType.CREATED;
+    nock(basePath)
+      .post(parsedURL.path)
+      .reply(status, function (uri, requestBody) {
+        const hmac = crypto.createHmac('sha256', AppSecret);
+        hmac.update(requestBody.toString());
+        expect(this.req.headers.authorization).toBe(`Hydro ${hmac.digest('hex')}`);
+        return errMsg;
+      });
+    expect(await submitProto(e)).toBe(expected);
+  });
+
+  /**
+   * This would fail if we didn't have the right secret in place
+   */
+  test('Returns true when disabled', async () => {
+    setIsDisabled(true);
+    const e = new Action();
+    e.type = ActionType.CREATED;
+    expect(await submitProto(e)).toBe(true);
+  });
+});

--- a/test/unit/tracking.test.js
+++ b/test/unit/tracking.test.js
@@ -14,7 +14,6 @@ const { Action, ActionType } = require('../../lib/proto/v0/action');
 const parsedURL = url.parse(BaseURL);
 const basePath = parsedURL.href.replace(parsedURL.path, '');
 const origDisabledState = isDisabled();
-const AppSecret = process.env.HYDRO_APP_SECRET;
 
 beforeAll(() => {
   setIsDisabled(false);
@@ -37,8 +36,8 @@ describe('Hydro Gateway Protobuf Submissions', () => {
       .post(parsedURL.path)
       .reply(status, function (uri, requestBody) {
         expect(this.req.headers['x-hydro-app']).toBe('jira-integration');
-        const hmac = crypto.createHmac('sha256', AppSecret);
-        hmac.update(requestBody.toString());
+        const hmac = crypto.createHmac('sha256', process.env.HYDRO_APP_SECRET);
+        hmac.update(JSON.stringify(requestBody));
         expect(this.req.headers.authorization).toBe(`Hydro ${hmac.digest('hex')}`);
         return errMsg;
       });


### PR DESCRIPTION
This framework exists to send events to the Hydro HTTP Gateway, using the hmac signed payloads. This does not send the events yet, just builds out the initial framework, protobuf, and tests. A future PR will send the events.

The `TRACKING_DISABLED` env var is set to `true` in staging and prod vault configurations.