### PR TITLE
Let Github bots events trigger changes in Jira

### DIFF
--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -60,11 +60,6 @@ module.exports = function middleware(callback) {
     const gitHubInstallationId = context.payload.installation.id;
     context.log = context.log.child({ gitHubInstallationId });
 
-    if (context.payload.sender.type === 'Bot') {
-      context.log({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting futher execution since the sender is a bot');
-      return;
-    }
-
     if (isFromIgnoredRepo(context.payload)) {
       context.log({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting futher execution since the repository is explicilty ignored');
       return;


### PR DESCRIPTION
With Github pushing for using Github Apps and Actions instead of bot users this will only become more common to have user type «Bot» triggering webhooks.
I don’t see why there should be a difference when a bot or a real user makes some changes on Github that should be reflected in Jira.

Fixes #394