### PR TITLE
Allow state changes bot actions processing

### DIFF
--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -35,6 +35,11 @@ const isFromIgnoredRepo = (payload) =>
   // Repository: https://admin.github.com/stafftools/repositories/seequent/lf_github_testing
   payload.installation.id === 491520 && payload.repository.id === 205972230;
 
+const isStateChangeAction = (action) => [
+  'opened',
+  'closed',
+  'reopened',
+].includes(action);
 
 module.exports = function middleware(callback) {
   return withSentry(async (context) => {
@@ -60,8 +65,8 @@ module.exports = function middleware(callback) {
     const gitHubInstallationId = context.payload.installation.id;
     context.log = context.log.child({ gitHubInstallationId });
 
-    if (context.payload.sender.type === 'Bot') {
-      context.log({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting futher execution since the sender is a bot');
+    if (context.payload.sender.type === 'Bot' && !isStateChangeAction(context.payload.action)) {
+      context.log({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting futher execution since the sender is a bot and action is not a state change');
       return;
     }
 


### PR DESCRIPTION
This is a proposition following the discussion in #291 

We still ignore bot events _except_ state changes, because the integration never updates PR states by itself, triggering no events, and we still avoid infinite event loops.