### PR TITLE
[ARC-35] security vulnerability in markdown

### DIFF
--- a/lib/jira/util/index.js
+++ b/lib/jira/util/index.js
@@ -1,6 +1,30 @@
-const { markdown } = require('markdown');
-
 module.exports = function (jiraClient) {
+  const containsReferenceLink = (line) => {
+    // reference text links should have 2 parts only
+    if (line.split(' ').length === 2) {
+      const hasSquareBrackets = line.charAt(0) === '[' && line.includes(']:');
+      const hasUrl = line.includes('http://') || line.includes('https://');
+
+      return hasSquareBrackets && hasUrl;
+    }
+
+    return false;
+  };
+
+  // Parse our existing issue text, pulling out any existing reference links.
+  // if reference links exist, returns array of issue keys. For example, the following
+  // reference links would return [ 'TEST-2019', 'TEST-2020' ]
+  // [TEST-2019]: http://example.com/browse/TEST-2019
+  // [TEST-2020]: https://example.com/browse/TEST-2020
+  // if no issue keys exist, return []
+  const checkForReferenceText = (text) => {
+    const splitTextByNewLine = text.split('\n');
+
+    return splitTextByNewLine
+      .filter((line) => containsReferenceLink(line))
+      .map((referenceLink) => referenceLink.slice(1, referenceLink.indexOf(']')));
+  };
+
   function addJiraIssueLinks(text, issues) {
     const referenceRegex = /\[([A-Z]+-[0-9]+)\](?!\()/g;
     const issueMap = issues.reduce((issueMap, issue) => ({
@@ -9,10 +33,7 @@ module.exports = function (jiraClient) {
     }), {});
 
     const links = [];
-
-    // Attempt to parse our existing issue text, pulling out any existing reference links.
-    const [, { references }] = markdown.parse(text);
-    const keys = references ? Object.keys(references) : [];
+    const keys = checkForReferenceText(text);
 
     // Parse the text up to a maximum amount of characters.
     while (referenceRegex.lastIndex < 1000) {
@@ -23,9 +44,8 @@ module.exports = function (jiraClient) {
       }
 
       const [, key] = match;
-
       // If we already have a reference link, or the issue is not valid, skip it.
-      if (keys.includes(key.toLowerCase()) || !issueMap[key]) {
+      if (keys.includes(key) || !issueMap[key]) {
         continue;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10449,24 +10449,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
-      "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
-      "requires": {
-        "nopt": "~2.1.1"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-          "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
-          "requires": {
-            "abbrev": "1"
-          }
-        }
-      }
-    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "helmet": "^3.21.2",
     "hot-shots": "^7.4.1",
     "ioredis": "^4.16.3",
-    "markdown": "^0.5.0",
     "moment": "^2.24.0",
     "moo": "^0.5.0",
     "newrelic": "^6.2.0",

--- a/test/fixtures/text/find-existing-references.rendered.md
+++ b/test/fixtures/text/find-existing-references.rendered.md
@@ -1,0 +1,8 @@
+#### [TEST-2019]
+
+[TEST-2019]: https://example.com/browse/TEST-2019 This issue is related to [TEST-2020] and [TEST-2021] and this is [TEST-2020]: https://example.com/browse/TEST-2020 is randomly placed in the text.
+
+[TEST-2019]: http://example.com/browse/TEST-2019
+[TEST-2020]: https://example.com/browse/TEST-2020
+
+[TEST-2021]: http://example.com/browse/TEST-2021

--- a/test/fixtures/text/find-existing-references.source.md
+++ b/test/fixtures/text/find-existing-references.source.md
@@ -1,0 +1,6 @@
+#### [TEST-2019]
+
+[TEST-2019]: https://example.com/browse/TEST-2019 This issue is related to [TEST-2020] and [TEST-2021] and this is [TEST-2020]: https://example.com/browse/TEST-2020 is randomly placed in the text.
+
+[TEST-2019]: http://example.com/browse/TEST-2019
+[TEST-2020]: https://example.com/browse/TEST-2020

--- a/test/unit/jira/util.test.js
+++ b/test/unit/jira/util.test.js
@@ -24,7 +24,7 @@ describe('Jira util', () => {
       util = getJiraUtil(jiraClient);
     });
 
-    test('it should handle multiple Jira references appropriately', () => {
+    it('it should handle multiple Jira references appropriately', () => {
       const { source, rendered } = loadFixture('multiple-links');
       const issues = [
         {
@@ -76,7 +76,6 @@ describe('Jira util', () => {
           },
         },
       ];
-
       const result = util.addJiraIssueLinks(source, issues);
       expect(result).toBe(rendered);
     });
@@ -102,6 +101,34 @@ describe('Jira util', () => {
       ];
 
       const result = util.addJiraIssueLinks(source, issues);
+      expect(result).toBe(rendered);
+    });
+
+    it('should only pull issue keys from reference links', () => {
+      const { source, rendered } = loadFixture('find-existing-references');
+      const issues = [
+        {
+          key: 'TEST-2019',
+          fields: {
+            summary: 'First Issue',
+          },
+        },
+        {
+          key: 'TEST-2020',
+          fields: {
+            summary: 'Second Issue',
+          },
+        },
+        {
+          key: 'TEST-2021',
+          fields: {
+            summary: 'Third Issue',
+          },
+        },
+      ];
+
+      const result = util.addJiraIssueLinks(source, issues);
+
       expect(result).toBe(rendered);
     });
   });


### PR DESCRIPTION
Resolved markdown vulnerability by removing markdown.js library and adding a block of code to handle pulling issue keys from reference text.

<img width="1637" alt="Screen Shot 2021-03-29 at 5 00 54 pm" src="https://user-images.githubusercontent.com/37155488/113664537-455cec80-96ef-11eb-8a2f-3cfd79737c21.png">
