### PR TITLE
Update CONTRIBUTING.md to specify app is running on Node 12 version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,7 @@ Please ensure that you have [homebrew](https://brew.sh/) installed. Instructions
 
 This app is written in [ES6 JavaScript](https://nodejs.org/en/docs/es6/) and runs on [Node.js](https://nodejs.org/).
 
-Required version of Node: v10.13.0
-
-**WARNING:**  Newer versions of Node do not work with "pg": "^7.4.3". It will simply hang on every DB operation with no logs whatsoever. Check you version with `node --version`; Run `nvm use 10.13` if you need to change it.
+**Required version of Node**: v12.x
 
 Install the dependencies by running:
 


### PR DESCRIPTION
As per the engine specifications in package.json, the app needs to be running on a version of Node 12. Previously we had stated that the app needed to run on `v10.13.0` to work with Postgres but this is now no longer needed. Running on 10.13.0 results in sync failures. Updating to a version of Node 12 resolves the sync status of failed.