### PR TITLE
ARC-36 fix failing test

### DIFF
--- a/test/unit/models/index.test.js
+++ b/test/unit/models/index.test.js
@@ -45,7 +45,7 @@ describe('test installation model', () => {
     eventType: 'installed',
   };
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     // Clean up the database
     await Installation.truncate({ cascade: true, restartIdentity: true });
     await Subscription.truncate({ cascade: true, restartIdentity: true });

--- a/test/unit/models/index.test.js
+++ b/test/unit/models/index.test.js
@@ -45,11 +45,13 @@ describe('test installation model', () => {
     eventType: 'installed',
   };
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     // Clean up the database
     await Installation.truncate({ cascade: true, restartIdentity: true });
     await Subscription.truncate({ cascade: true, restartIdentity: true });
+  });
 
+  beforeAll(async () => {
     const installation = await Installation.install({
       host: existingInstallPayload.baseUrl,
       sharedSecret: existingInstallPayload.sharedSecret,


### PR DESCRIPTION
Currently, when you follow CONTRIBUTING.md in Github for Jira and get to the npm test step, one of the tests fail.

Failing test: updates all Subscriptions for a given jira clientKey when a site is renamed in test/unit/models/index.test.js
Fails with:

Expected: "https://renamed-user.atlassian.net"
Received: "https://existing-instance.atlassian.net"
This was happening because we were calling Jest's beforeEach function which executes before every test in the scope. This meant that the renamed url of https://renamed-user.atlassian.net was being reset:

Screen Shot 2021-04-27 at 4 48 55 pm

Changes made so all tests pass:

- only making `truncate` calls from `beforeEach` (to make sure the db is clean before each test is run).
- running the remaining logic from `beforeAll` so it is only executed before all tests run.

Screen Shot 2021-04-27 at 4 50 39 pm