### PR TITLE
ARC-36 - add await to installation update

### DIFF
--- a/lib/models/installation.js
+++ b/lib/models/installation.js
@@ -95,11 +95,12 @@ class Installation extends Sequelize.Model {
         jiraHost: payload.host,
       }).then(async (record) => {
         const subscriptions = await Subscription.getAllForClientKey(record.clientKey);
-        subscriptions.forEach(subscription => {
-          subscription.update({
+        for (const subscription of subscriptions) {
+          await subscription.update({
             jiraHost: record.jiraHost,
           });
-        });
+        }
+
         return installation;
       });
     }

--- a/test/unit/models/index.test.js
+++ b/test/unit/models/index.test.js
@@ -46,12 +46,6 @@ describe('test installation model', () => {
   };
 
   beforeEach(async () => {
-    // Clean up the database
-    await Installation.truncate({ cascade: true, restartIdentity: true });
-    await Subscription.truncate({ cascade: true, restartIdentity: true });
-  });
-
-  beforeAll(async () => {
     const installation = await Installation.install({
       host: existingInstallPayload.baseUrl,
       sharedSecret: existingInstallPayload.sharedSecret,
@@ -70,6 +64,12 @@ describe('test installation model', () => {
       installationId: '2345',
       clientKey: installation.clientKey,
     });
+  });
+
+  afterEach(async () => {
+    // Clean up the database
+    await Installation.truncate({ cascade: true, restartIdentity: true });
+    await Subscription.truncate({ cascade: true, restartIdentity: true });
   });
 
   // Close connection when tests are done
@@ -116,6 +116,7 @@ describe('test installation model', () => {
     });
 
     const updatedSubscriptions = await Subscription.getAllForClientKey(updatedInstallation.clientKey);
+    expect(updatedSubscriptions.length).toBe(2);
 
     for (const subscription of updatedSubscriptions) {
       expect(subscription.jiraHost).toBe(renamedInstallPayload.baseUrl);


### PR DESCRIPTION
This is a secondary (and hopefully final) PR to fix the flaky test in the app. Turns out, we weren't awaiting `update` in the `install` method so our super speedy tests were receiving the returned valued for the existing subscription instead of the renamed one.