### PR TITLE
ARC-105: add block to handle rejected promise

### DIFF
--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -37,6 +37,12 @@ module.exports.processInstallation = (app, queues) => {
     // Get a fresh subscription instance
     const subscription = await Subscription.getSingleInstallation(jiraHost, installationId);
 
+    // handle promise rejection when an org is removed during a sync
+    if (subscription == null) {
+      console.error('Organization has been deleted. Other active syncs will continue.');
+      return;
+    }
+
     const status = edges.length > 0 ? 'pending' : 'complete';
     app.log(`Updating job status for installationId=${installationId}, repositoryId=${repositoryId}, task=${task}, status=${status}`);
     subscription.set(`repoSyncState.repos.${repositoryId}.${task}Status`, status);

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -39,7 +39,7 @@ module.exports.processInstallation = (app, queues) => {
 
     // handle promise rejection when an org is removed during a sync
     if (subscription == null) {
-      console.error('Organization has been deleted. Other active syncs will continue.');
+      console.log('Organization has been deleted. Other active syncs will continue.');
       return;
     }
 

--- a/lib/sync/installation.js
+++ b/lib/sync/installation.js
@@ -39,7 +39,7 @@ module.exports.processInstallation = (app, queues) => {
 
     // handle promise rejection when an org is removed during a sync
     if (subscription == null) {
-      console.log('Organization has been deleted. Other active syncs will continue.');
+      app.log('Organization has been deleted. Other active syncs will continue.');
       return;
     }
 


### PR DESCRIPTION
When a user removes an org during an active sync an unhandled error is thrown in the console.

<img width="1009" alt="unhandled-promise-rejection" src="https://user-images.githubusercontent.com/37155488/116833262-a3e88e00-abfb-11eb-846e-f1f2393c0c5a.png">

I've added a conditional block to simply log a message to the console when a subscription is `null` and return. All other active syncs continue.


https://user-images.githubusercontent.com/37155488/116833288-cd091e80-abfb-11eb-9daf-326cef6067eb.mov

