### PR TITLE
ARC-114: Allow bots to trigger changes

### DIFF
--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -65,13 +65,15 @@ module.exports = function middleware(callback) {
     const gitHubInstallationId = context.payload.installation.id;
     context.log = context.log.child({ gitHubInstallationId });
 
+    // Edit actions are not allowed because they trigger this Jira integration to write data in GitHub and can trigger events, causing an infinite loop.
+    // State change actions are allowed because they're one-time actions, therefore they won’t cause a loop.
     if (context.payload.sender.type === 'Bot' && !isStateChangeAction(context.payload.action)) {
       context.log({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting further execution since the sender is a bot and action is not a state change');
       return;
     }
 
     if (isFromIgnoredRepo(context.payload)) {
-      context.log({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting further execution since the repository is explicilty ignored');
+      context.log({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting further execution since the repository is explicitly ignored');
       return;
     }
 

--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -66,12 +66,12 @@ module.exports = function middleware(callback) {
     context.log = context.log.child({ gitHubInstallationId });
 
     if (context.payload.sender.type === 'Bot' && !isStateChangeAction(context.payload.action)) {
-      context.log({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting futher execution since the sender is a bot and action is not a state change');
+      context.log({ noop: 'bot', botId: context.payload.sender.id, botLogin: context.payload.sender.login }, 'Halting further execution since the sender is a bot and action is not a state change');
       return;
     }
 
     if (isFromIgnoredRepo(context.payload)) {
-      context.log({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting futher execution since the repository is explicilty ignored');
+      context.log({ noop: 'ignored_repo', installation_id: context.payload.installation.id, repository_id: context.payload.repository.id }, 'Halting further execution since the repository is explicilty ignored');
       return;
     }
 

--- a/test/fixtures/pull-request-triggered-by-bot.json
+++ b/test/fixtures/pull-request-triggered-by-bot.json
@@ -1,0 +1,143 @@
+[
+  {
+    "name": "pull_request",
+    "payload": {
+      "action": "opened",
+      "repository": {
+        "id": "test-repo-id",
+        "name": "test-repo-name",
+        "full_name": "example/test-repo-name",
+        "html_url": "test-repo-url",
+        "owner": {
+          "login": "test-repo-owner"
+        }
+      },
+      "pull_request": {
+        "id": "test-pull-request-id",
+        "number": 1,
+        "state": "open",
+        "title": "[TEST-123] Test pull request.",
+        "body": "[TEST-123] body of the test pull request.",
+        "comments": "test-pull-request-comment-count",
+        "html_url": "test-pull-request-url",
+        "head": {
+          "repo": {
+            "html_url": "test-pull-request-head-url"
+          },
+          "ref": "TEST-321-test-pull-request-head-ref",
+          "sha": "test-pull-request-sha"
+        },
+        "base": {
+          "repo": {
+            "html_url": "test-pull-request-base-url"
+          },
+          "ref": "test-pull-request-base-ref"
+        },
+        "user": {
+          "login": "test-pull-request-user-login"
+        },
+        "updated_at": "test-pull-request-update-time"
+      },
+      "sender": {
+        "type": "Bot"
+      },
+      "installation": {
+        "id": 1234
+      }
+    }
+  },
+  {
+    "name": "pull_request",
+    "payload": {
+      "action": "closed",
+      "repository": {
+        "id": "test-repo-id",
+        "name": "test-repo-name",
+        "full_name": "example/test-repo-name",
+        "html_url": "test-repo-url",
+        "owner": {
+          "login": "test-repo-owner"
+        }
+      },
+      "pull_request": {
+        "id": "test-pull-request-id",
+        "number": 1,
+        "state": "merged",
+        "title": "[TEST-123] Test pull request.",
+        "body": "[TEST-123] body of the test pull request.",
+        "comments": "test-pull-request-comment-count",
+        "html_url": "test-pull-request-url",
+        "head": {
+          "repo": {
+            "html_url": "test-pull-request-head-url"
+          },
+          "ref": "TEST-321-test-pull-request-head-ref",
+          "sha": "test-pull-request-sha"
+        },
+        "base": {
+          "repo": {
+            "html_url": "test-pull-request-base-url"
+          },
+          "ref": "test-pull-request-base-ref"
+        },
+        "user": {
+          "login": "test-pull-request-user-login"
+        },
+        "updated_at": "test-pull-request-update-time"
+      },
+      "sender": {
+        "type": "Bot"
+      },
+      "installation": {
+        "id": 1234
+      }
+    }
+  },
+  {
+    "name": "pull_request",
+    "payload": {
+      "action": "reopened",
+      "repository": {
+        "id": "test-repo-id",
+        "name": "test-repo-name",
+        "full_name": "example/test-repo-name",
+        "html_url": "test-repo-url",
+        "owner": {
+          "login": "test-repo-owner"
+        }
+      },
+      "pull_request": {
+        "id": "test-pull-request-id",
+        "number": 1,
+        "state": "open",
+        "title": "[TEST-123] Test pull request.",
+        "body": "[TEST-123] body of the test pull request.",
+        "comments": "test-pull-request-comment-count",
+        "html_url": "test-pull-request-url",
+        "head": {
+          "repo": {
+            "html_url": "test-pull-request-head-url"
+          },
+          "ref": "TEST-321-test-pull-request-head-ref",
+          "sha": "test-pull-request-sha"
+        },
+        "base": {
+          "repo": {
+            "html_url": "test-pull-request-base-url"
+          },
+          "ref": "test-pull-request-base-ref"
+        },
+        "user": {
+          "login": "test-pull-request-user-login"
+        },
+        "updated_at": "test-pull-request-update-time"
+      },
+      "sender": {
+        "type": "Bot"
+      },
+      "installation": {
+        "id": 1234
+      }
+    }
+  }
+]

--- a/test/safe/pull-request.test.js
+++ b/test/safe/pull-request.test.js
@@ -200,5 +200,255 @@ describe('GitHub Actions', () => {
         properties: { installationId: 1234 },
       }));
     });
+
+    it('should update the Jira issue with the linked GitHub pull_request if PR opened action was triggered by bot', async () => {
+      const payload = require('../fixtures/pull-request-triggered-by-bot.json');
+
+      const jiraApi = td.api('https://test-atlassian-instance.net');
+      const githubApi = td.api('https://api.github.com');
+
+      td.when(githubApi.get('/users/test-pull-request-user-login')).thenReturn({
+        login: 'test-pull-request-author-login',
+        avatar_url: 'test-pull-request-author-avatar',
+        html_url: 'test-pull-request-author-url',
+      });
+
+      td.when(jiraApi.get('/rest/api/latest/issue/TEST-123?fields=summary'))
+        .thenReturn({
+          key: 'TEST-123',
+          fields: {
+            summary: 'Example Issue',
+          },
+        });
+
+      Date.now = jest.fn(() => 12345678);
+
+      await app.receive(payload[0]);
+
+      td.verify(githubApi.patch('/repos/test-repo-owner/test-repo-name/issues/1', {
+        body: '[TEST-123] body of the test pull request.\n\n[TEST-123]: https://test-atlassian-instance.net/browse/TEST-123',
+        id: 'test-pull-request-id',
+      }));
+
+      td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
+        preventTransitions: false,
+        repositories: [
+          {
+            name: 'example/test-repo-name',
+            url: 'test-repo-url',
+            id: 'test-repo-id',
+            branches: [
+              {
+                createPullRequestUrl: 'test-pull-request-head-url/pull/new/TEST-321-test-pull-request-head-ref',
+                lastCommit: {
+                  author: {
+                    name: 'test-pull-request-author-login',
+                  },
+                  authorTimestamp: 'test-pull-request-update-time',
+                  displayId: 'test-p',
+                  fileCount: 0,
+                  hash: 'test-pull-request-sha',
+                  id: 'test-pull-request-sha',
+                  issueKeys: ['TEST-123', 'TEST-321'],
+                  message: 'n/a',
+                  updateSequenceId: 12345678,
+                  url: 'test-pull-request-head-url/commit/test-pull-request-sha',
+                },
+                id: 'TEST-321-test-pull-request-head-ref',
+                issueKeys: ['TEST-123', 'TEST-321'],
+                name: 'TEST-321-test-pull-request-head-ref',
+                url: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
+                updateSequenceId: 12345678,
+              },
+            ],
+            pullRequests: [
+              {
+                author: {
+                  name: 'test-pull-request-author-login',
+                  avatar: 'test-pull-request-author-avatar',
+                  url: 'test-pull-request-author-url',
+                },
+                commentCount: 'test-pull-request-comment-count',
+                destinationBranch: 'test-pull-request-base-url/tree/test-pull-request-base-ref',
+                displayId: '#1',
+                id: 1,
+                issueKeys: ['TEST-123', 'TEST-321'],
+                lastUpdate: 'test-pull-request-update-time',
+                sourceBranch: 'TEST-321-test-pull-request-head-ref',
+                sourceBranchUrl: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
+                status: 'OPEN',
+                title: '[TEST-123] Test pull request.',
+                timestamp: 'test-pull-request-update-time',
+                url: 'test-pull-request-url',
+                updateSequenceId: 12345678,
+              },
+            ],
+            updateSequenceId: 12345678,
+          },
+        ],
+        properties: {
+          installationId: 1234,
+        },
+      }));
+    });
+
+    it('should update the Jira issue with the linked GitHub pull_request if PR closed action was triggered by bot', async () => {
+      const payload = require('../fixtures/pull-request-triggered-by-bot.json');
+
+      const jiraApi = td.api('https://test-atlassian-instance.net');
+      const githubApi = td.api('https://api.github.com');
+
+      td.when(githubApi.get('/users/test-pull-request-user-login')).thenReturn({
+        login: 'test-pull-request-author-login',
+        avatar_url: 'test-pull-request-author-avatar',
+        html_url: 'test-pull-request-author-url',
+      });
+
+      td.when(jiraApi.get('/rest/api/latest/issue/TEST-123?fields=summary'))
+        .thenReturn({
+          key: 'TEST-123',
+          fields: {
+            summary: 'Example Issue',
+          },
+        });
+
+      Date.now = jest.fn(() => 12345678);
+
+      await app.receive(payload[1]);
+
+      td.verify(githubApi.patch('/repos/test-repo-owner/test-repo-name/issues/1', {
+        body: '[TEST-123] body of the test pull request.\n\n[TEST-123]: https://test-atlassian-instance.net/browse/TEST-123',
+        id: 'test-pull-request-id',
+      }));
+
+      td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
+        preventTransitions: false,
+        repositories: [
+          {
+            name: 'example/test-repo-name',
+            url: 'test-repo-url',
+            id: 'test-repo-id',
+            branches: [],
+            pullRequests: [
+              {
+                author: {
+                  name: 'test-pull-request-author-login',
+                  avatar: 'test-pull-request-author-avatar',
+                  url: 'test-pull-request-author-url',
+                },
+                commentCount: 'test-pull-request-comment-count',
+                destinationBranch: 'test-pull-request-base-url/tree/test-pull-request-base-ref',
+                displayId: '#1',
+                id: 1,
+                issueKeys: ['TEST-123', 'TEST-321'],
+                lastUpdate: 'test-pull-request-update-time',
+                sourceBranch: 'TEST-321-test-pull-request-head-ref',
+                sourceBranchUrl: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
+                status: 'MERGED',
+                title: '[TEST-123] Test pull request.',
+                timestamp: 'test-pull-request-update-time',
+                url: 'test-pull-request-url',
+                updateSequenceId: 12345678,
+              },
+            ],
+            updateSequenceId: 12345678,
+          },
+        ],
+        properties: {
+          installationId: 1234,
+        },
+      }));
+    });
+
+    it('should update the Jira issue with the linked GitHub pull_request if PR reopened action was triggered by bot', async () => {
+      const payload = require('../fixtures/pull-request-triggered-by-bot.json');
+
+      const jiraApi = td.api('https://test-atlassian-instance.net');
+      const githubApi = td.api('https://api.github.com');
+
+      td.when(githubApi.get('/users/test-pull-request-user-login')).thenReturn({
+        login: 'test-pull-request-author-login',
+        avatar_url: 'test-pull-request-author-avatar',
+        html_url: 'test-pull-request-author-url',
+      });
+
+      td.when(jiraApi.get('/rest/api/latest/issue/TEST-123?fields=summary'))
+        .thenReturn({
+          key: 'TEST-123',
+          fields: {
+            summary: 'Example Issue',
+          },
+        });
+
+      Date.now = jest.fn(() => 12345678);
+
+      await app.receive(payload[2]);
+
+      td.verify(githubApi.patch('/repos/test-repo-owner/test-repo-name/issues/1', {
+        body: '[TEST-123] body of the test pull request.\n\n[TEST-123]: https://test-atlassian-instance.net/browse/TEST-123',
+        id: 'test-pull-request-id',
+      }));
+
+      td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
+        preventTransitions: false,
+        repositories: [
+          {
+            name: 'example/test-repo-name',
+            url: 'test-repo-url',
+            id: 'test-repo-id',
+            branches: [
+              {
+                createPullRequestUrl: 'test-pull-request-head-url/pull/new/TEST-321-test-pull-request-head-ref',
+                lastCommit: {
+                  author: {
+                    name: 'test-pull-request-author-login',
+                  },
+                  authorTimestamp: 'test-pull-request-update-time',
+                  displayId: 'test-p',
+                  fileCount: 0,
+                  hash: 'test-pull-request-sha',
+                  id: 'test-pull-request-sha',
+                  issueKeys: ['TEST-123', 'TEST-321'],
+                  message: 'n/a',
+                  updateSequenceId: 12345678,
+                  url: 'test-pull-request-head-url/commit/test-pull-request-sha',
+                },
+                id: 'TEST-321-test-pull-request-head-ref',
+                issueKeys: ['TEST-123', 'TEST-321'],
+                name: 'TEST-321-test-pull-request-head-ref',
+                url: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
+                updateSequenceId: 12345678,
+              },
+            ],
+            pullRequests: [
+              {
+                author: {
+                  name: 'test-pull-request-author-login',
+                  avatar: 'test-pull-request-author-avatar',
+                  url: 'test-pull-request-author-url',
+                },
+                commentCount: 'test-pull-request-comment-count',
+                destinationBranch: 'test-pull-request-base-url/tree/test-pull-request-base-ref',
+                displayId: '#1',
+                id: 1,
+                issueKeys: ['TEST-123', 'TEST-321'],
+                lastUpdate: 'test-pull-request-update-time',
+                sourceBranch: 'TEST-321-test-pull-request-head-ref',
+                sourceBranchUrl: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
+                status: 'OPEN',
+                title: '[TEST-123] Test pull request.',
+                timestamp: 'test-pull-request-update-time',
+                url: 'test-pull-request-url',
+                updateSequenceId: 12345678,
+              },
+            ],
+            updateSequenceId: 12345678,
+          },
+        ],
+        properties: {
+          installationId: 1234,
+        },
+      }));
+    });
   });
 });

--- a/test/unit/models/index.test.js
+++ b/test/unit/models/index.test.js
@@ -49,7 +49,9 @@ describe('test installation model', () => {
     // Clean up the database
     await Installation.truncate({ cascade: true, restartIdentity: true });
     await Subscription.truncate({ cascade: true, restartIdentity: true });
+  });
 
+  beforeAll(async () => {
     const installation = await Installation.install({
       host: existingInstallPayload.baseUrl,
       sharedSecret: existingInstallPayload.sharedSecret,


### PR DESCRIPTION
This PR adds tests to https://github.com/integrations/jira/pull/413.

Points to help us understand why having an exception to allow bots events only on PR state changes sound reasonable:

- We don't see how we can end up in a bot feedback loop situation if we allow bot events processing only for those, given the fact that this integration does not update PR states by itself.

- The act of merging - which is inherently a one-time action - won’t cause a loop so the bot-filter can be dropped for merge hooks, but left in place for other types of hooks so that the status could be properly posted in JIRA.

- The infinite loop issue may only happen on comment/description edition because it is the only case where this Jira integration actually writes data in GitHub and can trigger events. For that reason, we won’t add edited to the list of actions. I.e. If two bots are both set to auto-respond to all comments, you'd get an infinite loop.