### PR TITLE
adding .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+# editorconfig-tools is unable to ignore longs strings or urls
+max_line_length = off
+
+[CHANGELOG.md]
+indent_size = unset

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,7 @@
     "jest": true
   },
   "globals": {
-    "td": "writeable"
+    "td": "writable"
   },
   "plugins": [
     "no-only-tests",


### PR DESCRIPTION
I was getting annoyed when I was formatting with my IDE, which is defaulted to use tabs instead of spaces, and was breaking eslint rules.  Easiest way to do this is by having a .editorconfig file that specifies indent and space/tabs.  This one is based on the [airbnb javascript .editorconfig](https://github.com/airbnb/javascript/blob/master/.editorconfig) since we're already using their eslint config as well :)