### PR TITLE
ARC-136 remove csrfProtection middleware from jira/sync to resolve retry issue in Safari

### DIFF
--- a/lib/frontend/app.js
+++ b/lib/frontend/app.js
@@ -98,7 +98,7 @@ module.exports = (appTokenGenerator) => {
 
   app.get('/jira/configuration', csrfProtection, verifyJiraMiddleware, getJiraConfiguration);
   app.delete('/jira/configuration', verifyJiraMiddleware, deleteJiraConfiguration);
-  app.post('/jira/sync', csrfProtection, verifyJiraMiddleware, retrySync);
+  app.post('/jira/sync', verifyJiraMiddleware, retrySync);
 
   app.get('/', async (req, res, next) => {
     const { data: info } = (await res.locals.client.apps.getAuthenticated({}));


### PR DESCRIPTION
This change stems from https://github.com/integrations/jira/issues/151.

**Context**
Currently, if a customer clicks ‘Submit’ from the GitHub configuration page (jira-configuration.hbs) in Safari to retry a normal or full sync, nothing appears to happen. There is no feedback in the UI and the customer has no idea what’s happened. The error logged to the console in production is Failed to load resource: the server responded with a status of 400 (Bad Request). In development it’s Failed to load resource: the server responded with a status of 403 (Forbidden) with an additional error thrown in the terminal by our web worker: ForbiddenError: invalid csrf token.

In March of 2020 apple updated Safari to block all 3rd party cookies. This means, when we make a request from a Jira site to a GitHub app, the request tries to send cookies from session storage that aren’t there.

**Browser Comparison - Network Req and Stored Cookies**
I’ve only included Chrome and Safari in this comparison but Firefox behaves the same way as Chrome.

**Req Headers in Chrome vs Safari**

![image](https://user-images.githubusercontent.com/37155488/117092003-64a77200-ada0-11eb-986a-170428d4f021.png)

![image](https://user-images.githubusercontent.com/37155488/117092012-6c671680-ada0-11eb-9f52-f554a6ed88c5.png)

**Stored cookies for https://jira-integration-production.herokuapp.com  (this would be your ngrok/localtunnel APP_URL in dev - Chrome vs Safari**

![image](https://user-images.githubusercontent.com/37155488/117092055-81dc4080-ada0-11eb-8380-2a64fdc324cc.png)

![image](https://user-images.githubusercontent.com/37155488/117092066-856fc780-ada0-11eb-8a07-e33412948eb6.png)

If I uncheck Safari’s website tracking for ‘Prevent cross-site traffic’, I see a cookie header in the req, as well as cookies in storage for http://jira-integration-production.herokuapp.com.

![image](https://user-images.githubusercontent.com/37155488/117092076-8c96d580-ada0-11eb-8a15-72220ebf57d1.png)


**Where is this happening in our app?**
This appears to be the only place in our app where we try to make a request from a Jira site, in my case https://rachellerathbone.atlassian.net/, with a cookie for http://jira-integration-production.herokuapp.com. Apart from the POST request to jira/sync all other requests made to the production heroku url are made from https://jira.github.com/: new tab opens, request is made from new tab, tab closes and returns user to the Jira site. The POST request to retry a sync is the only request that doesn’t follow the same pattern implemented everywhere else in the application.


If I make the same request from one of our other pages, I see a cookie header.

![image](https://user-images.githubusercontent.com/37155488/117092095-9fa9a580-ada0-11eb-86f5-2b0205819f40.png)

This request ultimately still fails but it fails in verifyJiraMiddleware not on an invalid csrf token.

![Screen Shot 2021-05-05 at 12 52 06 pm](https://user-images.githubusercontent.com/37155488/117092117-b6e89300-ada0-11eb-8711-54d03ead2f53.png)

It appears this issue happens when we pass csrfProtection, make an AJAX request with _csrf as a param, and the request is made from the customer’s Jira site, not from a page off  https://jira.github.com/

After much deliberation about the path forward to resolve this issue that was first raised **2.5 years ago** we have decided to remove `csrfProtection`. It is not critical and we plan to follow up with a more thorough reimplementation once we have completed the migration of the app.
