### PR TITLE
HOTFIX-ARC-116: Add payload to sentry. Add try/catch when listing reviewers

### DIFF
--- a/lib/github/middleware.js
+++ b/lib/github/middleware.js
@@ -60,6 +60,7 @@ module.exports = function middleware(callback) {
       action: context.payload.action,
       id: context.id,
       repo: (context.payload.repository) ? context.repo() : undefined,
+      payload: context.payload,
     });
 
     const gitHubInstallationId = context.payload.installation.id;

--- a/lib/github/pull-request.js
+++ b/lib/github/pull-request.js
@@ -5,11 +5,17 @@ const parseSmartCommit = require('../transforms/smart-commit');
 
 module.exports = async (context, jiraClient, util) => {
   const author = await context.github.users.getByUsername({ username: context.payload.pull_request.user.login });
-  const reviews = await context.github.pulls.listReviews({
-    owner: context.payload.repository.owner.login,
-    repo: context.payload.repository.name,
-    pull_number: context.payload.pull_request.number,
-  });
+  let reviews = {};
+  try {
+    reviews = await context.github.pulls.listReviews({
+      owner: context.payload.repository.owner.login,
+      repo: context.payload.repository.name,
+      pull_number: context.payload.pull_request.number,
+    });
+  } catch (e) {
+    context.log(e, "Can't retrieve reviewers.");
+  }
+
   const { data: jiraPayload } = transformPullRequest(context.payload, author.data, reviews.data);
   const { pull_request: pullRequest } = context.payload;
 

--- a/test/safe/pull-request.test.js
+++ b/test/safe/pull-request.test.js
@@ -455,5 +455,144 @@ describe('GitHub Actions', () => {
         },
       }));
     });
+
+    it('should have reviewers on pull request action', async () => {
+      const payload = require('../fixtures/pull-request-basic.json');
+
+      const jiraApi = td.api('https://test-atlassian-instance.net');
+      const githubApi = td.api('https://api.github.com');
+
+      td.when(githubApi.get('/users/test-pull-request-user-login')).thenReturn({
+        login: 'test-pull-request-author-login',
+        avatar_url: 'test-pull-request-author-avatar',
+        html_url: 'test-pull-request-author-url',
+      });
+
+      td.when(githubApi.get('/repos/test-repo-owner/test-repo-name/pulls/1/reviews')).thenReturn([
+        {
+          id: 80,
+          node_id: 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3ODA=',
+          user: {
+            login: 'test-pull-request-reviewer-login',
+            id: 1,
+            node_id: 'MDQ6VXNlcjE=',
+            avatar_url: 'test-pull-request-reviewer-avatar',
+            gravatar_id: '',
+            url: 'https://api.github.com/users/reviewer',
+            html_url: 'https://github.com/reviewer',
+            followers_url: 'https://api.github.com/users/reviewer/followers',
+            following_url: 'https://api.github.com/users/reviewer/following{/other_user}',
+            gists_url: 'https://api.github.com/users/reviewer/gists{/gist_id}',
+            starred_url: 'https://api.github.com/users/reviewer/starred{/owner}{/repo}',
+            subscriptions_url: 'https://api.github.com/users/reviewer/subscriptions',
+            organizations_url: 'https://api.github.com/users/reviewer/orgs',
+            repos_url: 'https://api.github.com/users/reviewer/repos',
+            events_url: 'https://api.github.com/users/reviewer/events{/privacy}',
+            received_events_url: 'https://api.github.com/users/reviewer/received_events',
+            type: 'User',
+            site_admin: false,
+          },
+          body: 'Here is the body for the review.',
+          state: 'APPROVED',
+          html_url: 'https://github.com/test-repo-owner/test-repo-name/pull/1#pullrequestreview-80',
+          pull_request_url: 'https://api.github.com/repos/test-repo-owner/test-repo-name/pulls/1',
+          _links: {
+            html: {
+              href: 'https://github.com/test-repo-owner/test-repo-name/pull/1#pullrequestreview-80',
+            },
+            pull_request: {
+              href: 'https://api.github.com/repos/test-repo-owner/test-repo-name/pulls/1',
+            },
+          },
+          submitted_at: '2019-11-17T17:43:43Z',
+          commit_id: 'ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091',
+          author_association: 'COLLABORATOR',
+        },
+      ]);
+
+      td.when(jiraApi.get('/rest/api/latest/issue/TEST-123?fields=summary'))
+        .thenReturn({
+          key: 'TEST-123',
+          fields: {
+            summary: 'Example Issue',
+          },
+        });
+
+      Date.now = jest.fn(() => 12345678);
+
+      await app.receive(payload);
+
+      td.verify(githubApi.patch('/repos/test-repo-owner/test-repo-name/issues/1', {
+        body: '[TEST-123] body of the test pull request.\n\n[TEST-123]: https://test-atlassian-instance.net/browse/TEST-123',
+        id: 'test-pull-request-id',
+      }));
+
+      td.verify(jiraApi.post('/rest/devinfo/0.10/bulk', {
+        preventTransitions: false,
+        repositories: [
+          {
+            name: 'example/test-repo-name',
+            url: 'test-repo-url',
+            id: 'test-repo-id',
+            branches: [
+              {
+                createPullRequestUrl: 'test-pull-request-head-url/pull/new/TEST-321-test-pull-request-head-ref',
+                lastCommit: {
+                  author: {
+                    name: 'test-pull-request-author-login',
+                  },
+                  authorTimestamp: 'test-pull-request-update-time',
+                  displayId: 'test-p',
+                  fileCount: 0,
+                  hash: 'test-pull-request-sha',
+                  id: 'test-pull-request-sha',
+                  issueKeys: ['TEST-123', 'TEST-321'],
+                  message: 'n/a',
+                  updateSequenceId: 12345678,
+                  url: 'test-pull-request-head-url/commit/test-pull-request-sha',
+                },
+                id: 'TEST-321-test-pull-request-head-ref',
+                issueKeys: ['TEST-123', 'TEST-321'],
+                name: 'TEST-321-test-pull-request-head-ref',
+                url: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
+                updateSequenceId: 12345678,
+              },
+            ],
+            pullRequests: [
+              {
+                author: {
+                  name: 'test-pull-request-author-login',
+                  avatar: 'test-pull-request-author-avatar',
+                  url: 'test-pull-request-author-url',
+                },
+                commentCount: 'test-pull-request-comment-count',
+                destinationBranch: 'test-pull-request-base-url/tree/test-pull-request-base-ref',
+                displayId: '#1',
+                id: 1,
+                reviewers: [{
+                  name: 'test-pull-request-reviewer-login',
+                  approvalStatus: 'APPROVED',
+                  url: 'https://github.com/reviewer',
+                  avatar: 'test-pull-request-reviewer-avatar',
+                }],
+                issueKeys: ['TEST-123', 'TEST-321'],
+                lastUpdate: 'test-pull-request-update-time',
+                sourceBranch: 'TEST-321-test-pull-request-head-ref',
+                sourceBranchUrl: 'test-pull-request-head-url/tree/TEST-321-test-pull-request-head-ref',
+                status: 'OPEN',
+                title: '[TEST-123] Test pull request.',
+                timestamp: 'test-pull-request-update-time',
+                url: 'test-pull-request-url',
+                updateSequenceId: 12345678,
+              },
+            ],
+            updateSequenceId: 12345678,
+          },
+        ],
+        properties: {
+          installationId: 1234,
+        },
+      }));
+    });
   });
 });


### PR DESCRIPTION
We're still not sure how the pull request number would be missing from the payload. Adding the payload to Sentry so we can try to have more information. Also adding try/catch when listing reviewers and logging the exception.