### PR TITLE
HOTFIX ARC-116: adding logging of payload 

### DIFF
--- a/lib/github/pull-request.js
+++ b/lib/github/pull-request.js
@@ -13,7 +13,10 @@ module.exports = async (context, jiraClient, util) => {
       pull_number: context.payload.pull_request.number,
     });
   } catch (e) {
-    context.log(e, "Can't retrieve reviewers.");
+    context.log.warn({
+      error: e,
+      payload: context.payload,
+    }, "Can't retrieve reviewers.");
   }
 
   const { data: jiraPayload } = transformPullRequest(context.payload, author.data, reviews.data);


### PR DESCRIPTION
Need to better understand why the `listReviews` call is failing, adding payload information to the log, changing the log level to `warn` to make it more visible.  We need to understand who's it affecting and why.