### PR TITLE
ARC-254 fix metric name

### DIFF
--- a/src/config/metric-names.ts
+++ b/src/config/metric-names.ts
@@ -4,7 +4,6 @@ const server = 'app.server';
 export const metricError = {
   expressRateLimited: `${server}.error.express-rate-limited`,
   githubErrorRendered: `${frontend}.error.github-error-rendered`,
-  jiraConfiguration: `${server}.error.jira-configuration`,
 };
 
 export const metricHttpRequest = (metricName?: string) => {
@@ -26,3 +25,7 @@ export const metricSyncStatus = {
   stalled: `${server}.sync-status.stalled`,
   failed: `${server}.sync-status.failed`,
 };
+
+export const metricWebhooks = {
+  webhookEvent: `${server}.webhooks.webhook-events`,
+}

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -7,7 +7,7 @@ import { createBranch, deleteBranch } from './branch';
 import webhookTimeout from '../middleware/webhook-timeout';
 import bunyan from 'bunyan';
 import statsd from '../config/statsd';
-import { metricError } from '../config/metric-names';
+import { metricWebhooks } from '../config/metric-names';
 
 export default (robot) => {
   const logger = bunyan.createLogger({ name: 'github' });
@@ -23,7 +23,7 @@ export default (robot) => {
       `action: ${payload.action}`,
     ];
 
-    statsd.increment(metricError.jiraConfiguration, tags);
+    statsd.increment(metricWebhooks.webhookEvent, tags);
   });
 
   robot.on(


### PR DESCRIPTION
Bad copy and paste when setting up the metric names and bungled the naming of the webhook metric.