### PR TITLE
ARC-329 domain proxy to github app

### DIFF
--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -124,6 +124,7 @@ environmentOverrides:
             - github.stg.atlassian.com
           upstream_address:
             - address: jira-staging.githubapp.com
+          upstream_sni: jira-staging.githubapp.com
 
   prod:
     config:
@@ -139,4 +140,5 @@ environmentOverrides:
             - github.atlassian.com
           upstream_address:
             - address: jira.github.com
+          upstream_sni: jira.github.com
 

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -124,7 +124,7 @@ environmentOverrides:
             - github.stg.atlassian.com
           upstream_address:
             - address: jira-integration-staging.herokuapp.com
-#          upstream_sni: jira-integration-staging.herokuapp.com
+          upstream_sni: jira-integration-staging.herokuapp.com
 
   prod:
     config:
@@ -140,5 +140,4 @@ environmentOverrides:
             - github.atlassian.com
           upstream_address:
             - address: jira-integration-production.herokuapp.com
-#          upstream_sni: jira-integration-production.herokuapp.com
-
+          upstream_sni: jira-integration-production.herokuapp.com

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -123,8 +123,8 @@ environmentOverrides:
           domain:
             - github.stg.atlassian.com
           upstream_address:
-            - address: jira-staging.githubapp.com
-          upstream_sni: jira-staging.githubapp.com
+            - address: jira-integration-staging.herokuapp.com
+#          upstream_sni: jira-integration-staging.herokuapp.com
 
   prod:
     config:
@@ -139,6 +139,6 @@ environmentOverrides:
           domain:
             - github.atlassian.com
           upstream_address:
-            - address: jira.github.com
-          upstream_sni: jira.github.com
+            - address: jira-integration-production.herokuapp.com
+#          upstream_sni: jira-integration-production.herokuapp.com
 

--- a/github-for-jira.sd.yml
+++ b/github-for-jira.sd.yml
@@ -124,7 +124,7 @@ environmentOverrides:
             - github.stg.atlassian.com
           upstream_address:
             - address: jira-integration-staging.herokuapp.com
-          upstream_sni: jira-integration-staging.herokuapp.com
+          rewrite: jira-integration-staging.herokuapp.com
 
   prod:
     config:
@@ -140,4 +140,4 @@ environmentOverrides:
             - github.atlassian.com
           upstream_address:
             - address: jira-integration-production.herokuapp.com
-          upstream_sni: jira-integration-production.herokuapp.com
+          rewrite: jira-integration-production.herokuapp.com


### PR DESCRIPTION
Fixed an issue with Global Edge proxy to rewrite the host parameter as heroku doesn't allow any other domain except the one specified in the app.