### PR TITLE
ARC-10: configuring proxy for outbound calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-for-jira",
+  "name": "@atlassian/github-for-jira",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -2357,6 +2357,11 @@
         }
       }
     },
+    "boolean": {
+      "version": "3.1.2",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/boolean/-/boolean-3.1.2.tgz",
+      "integrity": "sha1-4w8hCiawJFhIKozDU6sG8mKngMI="
+    },
     "bottleneck": {
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
@@ -3354,6 +3359,11 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha1-yccHdaScPQO8LAbZpzvlUPl4+LE="
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -3656,6 +3666,11 @@
         "es6-symbol": "~3.1.3",
         "next-tick": "~1.0.0"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0="
     },
     "es6-iterator": {
       "version": "2.0.3",
@@ -4772,7 +4787,7 @@
     },
     "foreachasync": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/foreachasync/-/foreachasync-3.0.0.tgz",
       "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY="
     },
     "form-data": {
@@ -4921,6 +4936,31 @@
         "is-glob": "^4.0.1"
       }
     },
+    "global-agent": {
+      "version": "1.13.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/global-agent/-/global-agent-1.13.1.tgz",
+      "integrity": "sha1-5OxaAlNu9Ac6zRKZ5b/4q2M0TwU=",
+      "requires": {
+        "core-js": "^3.1.4",
+        "es6-error": "^4.1.1",
+        "matcher": "^2.0.0",
+        "roarr": "^2.13.2",
+        "semver": "^6.1.2",
+        "serialize-error": "^4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.15.2",
+          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/core-js/-/core-js-3.15.2.tgz",
+          "integrity": "sha1-dAZg0v9V7zTOZk1+JFURnFvdPWE="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
     "global-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
@@ -4934,6 +4974,14 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globalthis": {
+      "version": "1.0.2",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/globalthis/-/globalthis-1.0.2.tgz",
+      "integrity": "sha1-KiNdNPTYA2IZ9+NJKbXenhgWa4s=",
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
     },
     "globby": {
       "version": "11.0.3",
@@ -6955,8 +7003,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "1.0.1",
@@ -7286,6 +7333,21 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "matcher": {
+      "version": "2.1.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/matcher/-/matcher-2.1.0.tgz",
+      "integrity": "sha1-ZOEEHBW5k+I7eG+TMgp0dL+DPCg=",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q="
+        }
       }
     },
     "md5": {
@@ -9394,6 +9456,26 @@
       "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
+    "roarr": {
+      "version": "2.15.4",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha1-9f55W3uDjM/jXcYI4Cgrnrouev0=",
+      "requires": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://packages.atlassian.com/api/npm/npm-remote/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha1-2hdlJiv4wPVxdJ8q1sJjACB65nM="
+        }
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -9588,6 +9670,11 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -9829,6 +9916,14 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
       "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
+    },
+    "serialize-error": {
+      "version": "4.1.0",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/serialize-error/-/serialize-error-4.1.0.tgz",
+      "integrity": "sha1-Y+HjPt4gvNidnwUo6kwV+/Dyt4o=",
+      "requires": {
+        "type-fest": "^0.3.0"
+      }
     },
     "serve-static": {
       "version": "1.14.1",
@@ -11393,7 +11488,7 @@
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "sequelize-encrypted": "^1.0.0",
     "throng": "^4.0.0",
     "tslib": "~2.2.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.2.4",
+    "global-agent": "^1.8.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "~4.23.0",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,11 +7,24 @@ const env = dotenv.config({
   path: path.resolve(process.cwd(), filename),
 });
 
+function getProxyFromEnvironment(): string{
+  let proxyHost: string = process.env.EXTERNAL_ONLY_PROXY_HOST;
+  let proxyPort: string = process.env.EXTERNAL_ONLY_PROXY_PORT;
+
+  if(!proxyHost || !proxyPort){
+    return '';
+  }
+  const proxyAddress = `http://${proxyHost}:${proxyPort}`;
+
+  return proxyAddress;
+}
+
 export default {
   MICROS_ENV: process.env.MICROS_ENV || 'development',
   MICROS_SERVICE_VERSION: process.env.MICROS_SERVICE_VERSION,
   NODE_ENV: process.env.NODE_ENV,
   SENTRY_DSN: process.env.SENTRY_DSN,
+  PROXY: getProxyFromEnvironment(),
   ...env.parsed,
 };
 

--- a/src/config/proxy.ts
+++ b/src/config/proxy.ts
@@ -1,0 +1,15 @@
+import envVars from './env';
+import {bootstrap} from 'global-agent';
+import Logger from 'bunyan';
+
+const logger = new Logger({name:'proxy'});
+
+if(envVars.PROXY){
+  logger.info(`configuring proxy: ${envVars.PROXY} for outbound calls`);
+  process.env.GLOBAL_AGENT_HTTP_PROXY = envVars.PROXY;
+  bootstrap();
+}else{
+  logger.info('configuring no proxy for outbound calls');
+}
+
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import App from './configure-robot';
 import bunyan from 'bunyan';
 import { exec } from 'child_process';
 import { initializeSentry } from './config/sentry';
+import './config/proxy';
 
 const isProd = process.env.NODE_ENV === 'production';
 const { redisOptions } = getRedisInfo('probot');

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -14,6 +14,7 @@ import AxiosErrorEventDecorator from '../models/axios-error-event-decorator';
 import SentryScopeProxy from '../models/sentry-scope-proxy';
 import { metricHttpRequest } from '../config/metric-names';
 import { initializeSentry } from '../config/sentry';
+import '../config/proxy';
 
 const CONCURRENT_WORKERS = process.env.CONCURRENT_WORKERS || 1;
 const client = new Redis(getRedisInfo('client').redisOptions);


### PR DESCRIPTION
Finally, a working solution. Tested in `ddev`, and the sync is going through with enabled IP allowlist.

This proxies ALL outbound calls now, not only the ones towards GitHub. This is not a problem when we're working with production Jira instance. When we're working with Jira dev instances, we have to disable the proxy, because the proxy doesn't allow calls to protected Atlassian resources.