### PR TITLE
ARC-8: Update permissions on docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,9 @@ Create a new [GitHub App](https://github.com/settings/apps), setting the followi
 
 Your new GitHub app will need the following repository permissions:
 
-+ Actions: Read-only
++ Actions: Read & write
 + Contents: Read & write
-+ Deployments: Read-only
++ Deployments: Read & write
 + Issues: Read & write
 + Metadata: Read-only
 + Pull requests: Read & write

--- a/app.yml
+++ b/app.yml
@@ -67,7 +67,7 @@ default_permissions:
 
   # Deployments and deployment statuses.
   # https://developer.github.com/v3/apps/permissions/#permission-on-deployments
-  deployments: read
+  deployments: write
 
   # Issues and related comments, assignees, labels, and milestones.
   # https://developer.github.com/v3/apps/permissions/#permission-on-issues
@@ -103,7 +103,7 @@ default_permissions:
 
   # GitHub Actions
   # https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-actions
-  actions: read
+  actions: write
 
   # Security events
   # https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-security-events


### PR DESCRIPTION
After testing in staging, we actually need Read & Write for displaying Builds and Deployments.