### PR TITLE
Arc 290 arc 334 centralise logging and cleanup logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,8 @@ TUNNEL_SUBDOMAIN=<subdomain>
 PRIVATE_KEY_PATH=<your-private-key>.pem
 ATLASSIAN_URL=https://<your-instance>.atlassian.net
 TRACKING_DISABLED=true
-HYDRO_BASE_URL=https://hydro-base-url.com/api/v1/events
-HYDRO_APP_SECRET=2dd220c366ec5b86104efd7324c2d405
+HYDRO_BASE_URL=
+HYDRO_APP_SECRET=
 
 # Use `trace` to get verbose logging or `info` to show less
 LOG_LEVEL=debug

--- a/.env.test
+++ b/.env.test
@@ -28,5 +28,5 @@ HYDRO_BASE_URL=https://hydro-base-url.com/api/v1/events
 HYDRO_APP_SECRET=2dd2testsecret2d405
 
 # Use `trace` to get verbose logging or `info` to show less
-LOG_LEVEL=info
+LOG_LEVEL=fatal
 WEBHOOK_PROXY_URL=http://localhost:8080/github/events

--- a/.env.test
+++ b/.env.test
@@ -25,7 +25,7 @@ PRIVATE_KEY_PATH=./test/setup/test-key.pem
 ATLASSIAN_URL=https://test-atlassian-instance.net
 TRACKING_DISABLED=true
 HYDRO_BASE_URL=https://hydro-base-url.com/api/v1/events
-HYDRO_APP_SECRET=2dd2testsecretc2d405
+HYDRO_APP_SECRET=2dd2testsecret2d405
 
 # Use `trace` to get verbose logging or `info` to show less
 LOG_LEVEL=info

--- a/.env.test
+++ b/.env.test
@@ -25,7 +25,7 @@ PRIVATE_KEY_PATH=./test/setup/test-key.pem
 ATLASSIAN_URL=https://test-atlassian-instance.net
 TRACKING_DISABLED=true
 HYDRO_BASE_URL=https://hydro-base-url.com/api/v1/events
-HYDRO_APP_SECRET=2dd220c366ec5b86104efd7324c2d405
+HYDRO_APP_SECRET=2dd2testsecretc2d405
 
 # Use `trace` to get verbose logging or `info` to show less
 LOG_LEVEL=info

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "prettier"
   ],
   "rules": {
-    "@typescript-eslint/explicit-module-boundary-types": "off"
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "no-console": "warn"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ The first time you run the app, simply run:
 ```
 npm install # installs node modules
 docker-compose up # Spin up docker containers
-npm run db:init # Creates DBs and initializes tables
+npm run db # Creates DBs and initializes tables
 ```
 
 From then on, to just run the app locally in development mode, just do `npm start`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "github-for-jira",
+  "name": "@atlassian/github-for-jira",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1376,6 +1376,14 @@
         }
       }
     },
+    "@types/bunyan-format": {
+      "version": "0.2.4",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/@types/bunyan-format/-/bunyan-format-0.2.4.tgz",
+      "integrity": "sha1-DrtEJad7XPodIB3oD7epy/+MRlk=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cache-manager": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@types/cache-manager/-/cache-manager-3.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "bottleneck": "^2.19.5",
     "bull": "^3.12.1",
     "bunyan": "^1.8.15",
+    "bunyan-format": "^0.2.1",
     "cookie-session": "^2.0.0-rc.1",
     "csurf": "^1.11.0",
     "date-fns": "^1.29.0",
@@ -84,7 +85,8 @@
     "sequelize-encrypted": "^1.0.0",
     "throng": "^4.0.0",
     "tslib": "~2.2.0",
-    "typescript": "~4.2.4"
+    "typescript": "~4.2.4",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "~4.23.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@sentry/node": "^6.8.0",
     "@types/bull": "^3.12.2",
     "@types/bunyan": "^1.8.6",
+    "@types/bunyan-format": "^0.2.4",
     "@types/cache-manager": "^3.4.0",
     "@types/cookie-session": "^2.0.42",
     "@types/csurf": "^1.11.1",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,7 +20,7 @@ import {
 import getRedisInfo from '../config/redis-info';
 import statsd, {elapsedTimeMetrics} from '../config/statsd';
 import {metricSyncStatus} from '../config/metric-names';
-import { logger } from 'probot/lib/logger';
+import logger from '../config/logger';
 
 const router = express.Router();
 const bodyParser = BodyParser.urlencoded({ extended: false });

--- a/src/config/enhance-octokit.ts
+++ b/src/config/enhance-octokit.ts
@@ -3,10 +3,10 @@ import statsd from './statsd';
 import {extractPath} from '../jira/client/axios';
 import {GitHubAPI} from 'probot';
 import {LoggerWithTarget, wrapLogger} from 'probot/lib/wrap-logger';
-import Logger from 'bunyan';
+import defaultLogger from './logger';
 import {metricHttpRequest} from './metric-names';
 
-const instrumentRequests = (octokit: GitHubAPI, log: Logger) => {
+const instrumentRequests = (octokit: GitHubAPI, log: LoggerWithTarget) => {
   octokit.hook.wrap('request', async (request, options) => {
     const requestStart = Date.now();
     let responseStatus = null;
@@ -42,8 +42,8 @@ const instrumentRequests = (octokit: GitHubAPI, log: Logger) => {
  * This acts like an Octokit plugin but works on Octokit instances.
  * (Because Probot instantiates the Octokit client for us, we can't use plugins.)
  */
-export default (octokit: GitHubAPI, logger?: LoggerWithTarget): GitHubAPI => {
-  logger = logger || wrapLogger(new Logger({name:'Octokit'}));
+export default (octokit: GitHubAPI, originalLogger?: LoggerWithTarget): GitHubAPI => {
+  const logger = originalLogger || wrapLogger(defaultLogger);
   OctokitError.wrapRequestErrors(octokit);
   instrumentRequests(octokit, logger);
   return octokit;

--- a/src/config/github-api.ts
+++ b/src/config/github-api.ts
@@ -1,5 +1,5 @@
 import {GitHubAPI} from 'probot';
-import bunyan from 'bunyan';
+import {getLogger} from './logger';
 import Redis from 'ioredis';
 import Bottleneck from 'bottleneck';
 import getRedisInfo from './redis-info';
@@ -11,7 +11,7 @@ const client = new Redis(redisOptions);
 const connection = new Bottleneck.IORedisConnection({client});
 
 export default (options: Partial<GithubAPIOptions> = {}): GitHubAPI => {
-  options.logger = options.logger || bunyan.createLogger({name: 'Github API'});
+  options.logger = options.logger || getLogger('Github API');
   if (process.env.NODE_ENV === 'test') {
     // Don't throttle at all
     options.throttle = {

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,8 +1,9 @@
-import Logger  from 'bunyan';;
+import Logger  from 'bunyan';
 import bformat from 'bunyan-format';
+import filteringStream from '../util/filteringStream'
 
 // add levelInString to include DEBUG | ERROR | INFO | WARN
-const formatOut = bformat({outputMode: 'bunyan', levelInString: true});
+const formatOut = filteringStream(bformat({outputMode: 'bunyan', levelInString: true}));
 
 const logger = Logger.createLogger(
   {
@@ -17,9 +18,16 @@ if (process.env.NODE_ENV === 'test') {
   logger.level(Logger.FATAL + 1);
 }
 
+//Override console.log with bunyan logger.
+//we shouldn't use console.log in our code, but it is done to catch
+//possible logs from third party libraries
+// eslint-disable-next-line no-console
 console.debug = logger.debug.bind(logger);
+// eslint-disable-next-line no-console
 console.error = logger.error.bind(logger);
+// eslint-disable-next-line no-console
 console.log = logger.info.bind(logger);
+// eslint-disable-next-line no-console
 console.warn = logger.warn.bind(logger);
 
 export const getLogger = (name: string, params?: Record<string, any>): Logger => {

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -8,7 +8,7 @@ const formatOut = filteringStream(bformat({outputMode: 'bunyan', levelInString: 
 const logger = Logger.createLogger(
   {
     name: 'github-for-jira',
-    loggerName: 'config.logger',
+    logger: 'config.logger',
     stream: formatOut,
   },
 );
@@ -30,9 +30,8 @@ console.log = logger.info.bind(logger);
 // eslint-disable-next-line no-console
 console.warn = logger.warn.bind(logger);
 
-export const getLogger = (name: string, params?: Record<string, any>): Logger => {
-  params = params || {};
-  return logger.child({...params, loggerName: name});
+export const getLogger = (name: string): Logger => {
+  return logger.child({logger: name});
 }
 
 export default logger

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,4 +1,4 @@
-import Logger  from 'bunyan';
+import Logger, {levelFromName} from 'bunyan';
 import bformat from 'bunyan-format';
 import filteringStream from '../util/filteringStream'
 
@@ -13,26 +13,31 @@ const logger = Logger.createLogger(
   },
 );
 
-// Suppress logging in tests
-if (process.env.NODE_ENV === 'test') {
-  logger.level(Logger.FATAL + 1);
+
+
+const logLevel = process.env.LOG_LEVEL || 'info';
+export const globalLoggingLevel = levelFromName[logLevel]
+
+logger.level(globalLoggingLevel);
+
+export const getLogger = (name: string): Logger => {
+  return logger.child({logger: name});
 }
 
 //Override console.log with bunyan logger.
 //we shouldn't use console.log in our code, but it is done to catch
 //possible logs from third party libraries
+const consoleLogger = getLogger('Console')
 // eslint-disable-next-line no-console
-console.debug = logger.debug.bind(logger);
+console.debug = consoleLogger.debug.bind(consoleLogger);
 // eslint-disable-next-line no-console
-console.error = logger.error.bind(logger);
+console.error = consoleLogger.error.bind(consoleLogger);
 // eslint-disable-next-line no-console
-console.log = logger.info.bind(logger);
+console.log = consoleLogger.info.bind(consoleLogger);
 // eslint-disable-next-line no-console
-console.warn = logger.warn.bind(logger);
+console.warn = consoleLogger.warn.bind(consoleLogger);
 
-export const getLogger = (name: string): Logger => {
-  return logger.child({logger: name});
-}
+
 
 export default logger
 

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -13,12 +13,27 @@ const logger = Logger.createLogger(
   },
 );
 
-
-
 const logLevel = process.env.LOG_LEVEL || 'info';
-export const globalLoggingLevel = levelFromName[logLevel]
-
+const globalLoggingLevel = levelFromName[logLevel] || Logger.INFO
 logger.level(globalLoggingLevel);
+
+
+// TODO Remove after upgrading Probot to the latest version (override logger via constructor instead)
+export const overrideProbotLoggingMethods = (probotLogger:Logger) => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+
+  // Remove  Default Probot Logging Stream
+  probotLogger.streams.pop();
+
+  // Replace with formatOut stream
+  probotLogger.addStream({
+    type: 'stream',
+    stream: formatOut,
+    closeOnExit: false,
+    level: globalLoggingLevel
+  });
+}
 
 export const getLogger = (name: string): Logger => {
   return logger.child({logger: name});

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,0 +1,31 @@
+import Logger  from 'bunyan';;
+import bformat from 'bunyan-format';
+
+// add levelInString to include DEBUG | ERROR | INFO | WARN
+const formatOut = bformat({outputMode: 'bunyan', levelInString: true});
+
+const logger = Logger.createLogger(
+  {
+    name: 'github-for-jira',
+    loggerName: 'config.logger',
+    stream: formatOut,
+  },
+);
+
+// Suppress logging in tests
+if (process.env.NODE_ENV === 'test') {
+  logger.level(Logger.FATAL + 1);
+}
+
+console.debug = logger.debug.bind(logger);
+console.error = logger.error.bind(logger);
+console.log = logger.info.bind(logger);
+console.warn = logger.warn.bind(logger);
+
+export const getLogger = (name: string, params?: Record<string, any>): Logger => {
+  params = params || {};
+  return logger.child({...params, loggerName: name});
+}
+
+export default logger
+

--- a/src/config/statsd.ts
+++ b/src/config/statsd.ts
@@ -1,5 +1,5 @@
 import { StatsD, StatsCb, Tags } from 'hot-shots';
-import bunyan from 'bunyan';
+import { getLogger } from './logger'
 import { Request, Response, NextFunction } from 'express';
 
 const isTest = process.env.NODE_ENV === 'test';
@@ -11,7 +11,7 @@ export const globalTags = {
   region: process.env.MICROS_AWS_REGION || 'localhost',
 };
 
-const logger = bunyan.createLogger({ name: 'statsd' });
+const logger = getLogger('statsd');
 
 const statsd = new StatsD({
   prefix: 'github-for-jira.',
@@ -38,7 +38,6 @@ function hrtimer() {
   };
 }
 
-const expressStatsdLogger = bunyan.createLogger({ name: 'elapsedTimeInMs' });
 export const elapsedTimeMetrics = (
   req: Request,
   res: Response,
@@ -49,7 +48,7 @@ export const elapsedTimeMetrics = (
   const tags = { path, method };
 
   res.once('finish', () => {
-    expressStatsdLogger.info(`${path} : ${elapsedTimeInMs()}`);
+    logger.info(`${path} : ${elapsedTimeInMs()}`);
     statsd.histogram('elapsedTimeInMs', elapsedTimeInMs(), tags);
   });
 

--- a/src/configure-robot.ts
+++ b/src/configure-robot.ts
@@ -13,6 +13,7 @@ import statsd from './config/statsd';
 import { isIp4InCidrs } from './config/cidr-validator';
 import Logger from 'bunyan';
 import { metricError } from './config/metric-names';
+import logMiddleware from "./middleware/log-middleware";
 
 /**
  * Get the list of GitHub CIDRs from the /meta endpoint
@@ -84,6 +85,8 @@ export default async (app: Application): Promise<Application> => {
 
     app.router.use(limiter);
   }
+
+  app.router.use(logMiddleware)
 
   // These incoming webhooks should skip rate limiting
   setupGitHub(app);

--- a/src/configure-robot.ts
+++ b/src/configure-robot.ts
@@ -11,7 +11,7 @@ import setupJira from './jira';
 import setupDeepcheck from './deepcheck';
 import statsd from './config/statsd';
 import { isIp4InCidrs } from './config/cidr-validator';
-import { Logger } from 'probot/lib/github/logging';
+import Logger from 'bunyan';
 import { metricError } from './config/metric-names';
 
 /**

--- a/src/deepcheck.ts
+++ b/src/deepcheck.ts
@@ -1,10 +1,10 @@
 import Redis from 'ioredis';
 import getRedisInfo from './config/redis-info';
-import { sequelize } from './models/sequelize';
-import { Application } from 'probot';
-import { Response } from 'express';
-import bunyan from 'bunyan';
-import { elapsedTimeMetrics } from './config/statsd';
+import {sequelize} from './models/sequelize';
+import {Application} from 'probot';
+import {Response} from 'express';
+import {elapsedTimeMetrics} from './config/statsd';
+import {getLogger} from './config/logger';
 
 /**
  * Create a /deepcheck and /healthcheck endpoints
@@ -22,7 +22,7 @@ export default (robot: Application) => {
    */
   app.get('/deepcheck', elapsedTimeMetrics, async (_, res: Response) => {
     let connectionsOk = true;
-    const deepcheckLogger = bunyan.createLogger({ name: 'deepcheck' });
+    const deepcheckLogger = getLogger('deepcheck');
 
     const redisPromise = cache.ping();
     const databasePromise = sequelize.authenticate();
@@ -51,7 +51,7 @@ export default (robot: Application) => {
   /**
    * /healtcheck endpoint to check that the app started properly
    */
-  const healthcheckLogger = bunyan.createLogger({ name: 'healthcheck' });
+  const healthcheckLogger = getLogger('healthcheck');
   app.get('/healthcheck', elapsedTimeMetrics, async (_, res: Response) => {
     res.status(200).send('OK');
     healthcheckLogger.info('Successfully called /healthcheck.');

--- a/src/frontend/github-client-middleware.ts
+++ b/src/frontend/github-client-middleware.ts
@@ -2,7 +2,7 @@ import GithubAPI from "../config/github-api";
 import { NextFunction, Request, RequestHandler, Response } from "express";
 import { App } from "@octokit/app";
 import { GitHubAPI } from "probot";
-import bunyan from 'bunyan';
+import { getLogger } from '../config/logger';
 
 export default (octokitApp: App): RequestHandler => (req: Request, res: Response, next: NextFunction): void => {
   if (req.session.githubToken) {
@@ -26,7 +26,7 @@ export default (octokitApp: App): RequestHandler => (req: Request, res: Response
 export const isAdmin = (githubClient: GitHubAPI) =>
   async (args: { org: string, username: string, type: string }): Promise<boolean> => {
     const { org, username, type } = args;
-    const logger = bunyan.createLogger({ name: 'GitHub Client Middleware' });
+    const logger = getLogger('github-client-middleware');
 
     // If this is a user installation, the "admin" is the user that owns the repo
     if (type === "User") {

--- a/src/frontend/github-oauth.ts
+++ b/src/frontend/github-oauth.ts
@@ -59,9 +59,8 @@ export default (opts: OAuthOptions): GithubOAuth => {
     res: Response,
     next: NextFunction,
   ): Promise<void> {
-    const { query } = url.parse(req.url, true);
-    const code = query.code as string;
-    const state = query.state as string;
+    const code = req.query.code as string;
+    const state = req.query.state as string;
 
     // Take save redirect url and delete it from session
     const redirectUrl = req.session[state] as string;

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -5,12 +5,12 @@ import pullRequest from './pull-request';
 import push from './push';
 import { createBranch, deleteBranch } from './branch';
 import webhookTimeout from '../middleware/webhook-timeout';
-import bunyan from 'bunyan';
 import statsd from '../config/statsd';
+import { getLogger } from '../config/logger'
 import { metricWebhooks } from '../config/metric-names';
 
 export default (robot) => {
-  const logger = bunyan.createLogger({ name: 'github' });
+  const logger = getLogger('github');
 
   // TODO: Need ability to remove these listeners, especially for testing...
   robot.on('*', (context) => {

--- a/src/jira/client/axios.ts
+++ b/src/jira/client/axios.ts
@@ -223,14 +223,16 @@ const instrumentRequest = (response) => {
  * @param {import('axios').AxiosError} error - The Axios error response object.
  * @returns {Promise<Error>} a rejected promise with the error inside.
  */
-const instrumentFailedRequest = (error) => {
-  if (error.response) {
-    instrumentRequest(error.response);
-  } else {
-    console.log('Error during Axios request has no response property:', error);
-  }
+const instrumentFailedRequest = (logger) => {
+  return (error) => {
+    if (error.response) {
+      instrumentRequest(error.response);
+    } else {
+      logger.error(error, 'Error during Axios request has no response property.');
+    }
 
-  return Promise.reject(error);
+    return Promise.reject(error);
+  };
 };
 
 /**
@@ -255,7 +257,7 @@ export default (
   instance.interceptors.request.use(setRequestStartTime);
   instance.interceptors.response.use(
     instrumentRequest,
-    instrumentFailedRequest,
+    instrumentFailedRequest(logger),
   );
 
   instance.interceptors.request.use(getAuthMiddleware(secret));

--- a/src/jira/client/axios.ts
+++ b/src/jira/client/axios.ts
@@ -1,11 +1,12 @@
 import Logger from 'bunyan';
-import axios, { AxiosInstance } from 'axios';
+import axios, {AxiosInstance} from 'axios';
 import jwt from 'atlassian-jwt';
 import url from 'url';
 import statsd from '../../config/statsd';
 import JiraClientError from './jira-client-error';
-import bunyan from 'bunyan';
-import { metricHttpRequest } from '../../config/metric-names';
+import {getLogger} from '../../config/logger'
+import {metricHttpRequest} from '../../config/metric-names';
+
 const instance = process.env.INSTANCE_NAME;
 const iss = `com.github.integration${instance ? `.${instance}` : ''}`;
 
@@ -15,22 +16,20 @@ declare module 'axios' {
     urlParams?: Record<string, string>;
   }
 }
+
 /**
  * Middleware to create a custom JWT for a request.
  *
  * @param {string} secret - The key to use to sign the JWT
  */
 function getAuthMiddleware(secret: string) {
-  const logger = bunyan.createLogger({ name: 'AXIOS' });
   return (
     /**
      * @param {import('axios').AxiosRequestConfig} config - The config for the outgoing request.
      * @returns {import('axios').AxiosRequestConfig} Updated axios config with authentication token.
      */
     (config) => {
-      logger.info(`AXIOS:`, config.url);
-      logger.info(`AXIOS URL:`, typeof config.url);
-      const { query, pathname } = url.parse(config.url, true);
+      const {query, pathname} = url.parse(config.url, true);
 
       const jwtToken = jwt.encode(
         {
@@ -80,17 +79,12 @@ function getErrorMiddleware(logger) {
      */
     (error) => {
       if (error.response) {
-        const { status, statusText } = error.response || {};
-        logger.debug(
-          {
-            params: error.config.urlParams,
-          },
-          `Jira request: ${error.request.method} ${error.request.path} - ${status} ${statusText}`,
-        );
+        const {status, statusText} = error.response || {};
 
-        if (status in JiraErrorCodes) {
-          logger.error(error.response.data, JiraErrorCodes[status]);
-        }
+        const errorMessage = status in JiraErrorCodes ? `Error calling Jira API. ${JiraErrorCodes[status]}` :
+          `Error calling Jira API. Response Code: ${status} ${statusText}`
+
+        logger.warn(error, {message: errorMessage, response_data: error.response.data});
 
         return Promise.reject(new JiraClientError(error));
       } else {
@@ -141,7 +135,7 @@ function getUrlMiddleware() {
      */
     (config) => {
       // eslint-disable-next-line prefer-const
-      let { query, pathname, ...rest } = url.parse(config.url, true);
+      let {query, pathname, ...rest} = url.parse(config.url, true);
       config.urlParams = config.urlParams || {};
 
       for (const param in config.urlParams) {
@@ -252,7 +246,7 @@ export default (
   secret: string,
   logger?: Logger,
 ): AxiosInstance => {
-  logger = logger || new Logger({ name: 'AxiosClient' });
+  logger = logger || getLogger('AxiosClient');
   const instance = axios.create({
     baseURL,
     timeout: +process.env.JIRA_TIMEOUT || 20000,

--- a/src/jira/index.ts
+++ b/src/jira/index.ts
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/node';
 
 import { Installation } from '../models';
 import { hasValidJwt } from './util/jwt';
-import logMiddleware from '../middleware/log-middleware';
 
 import connect from './connect';
 import disable from './disable';
@@ -44,7 +43,6 @@ export default (robot: Application): void => {
   // The request handler must be the first middleware on the app
   router.use(Sentry.Handlers.requestHandler());
   router.use(bodyParser.json());
-  router.use(logMiddleware);
 
   // Set up event handlers
   router.get('/atlassian-connect.json', connect);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,26 +2,28 @@ import './config/env'; // Important to be before other dependencies
 import throng from 'throng';
 import getRedisInfo from './config/redis-info';
 import * as PrivateKey from 'probot/lib/private-key';
-import { Probot } from 'probot';
+import { createProbot } from 'probot';
 import App from './configure-robot';
 import bunyan from 'bunyan';
 import { exec } from 'child_process';
 import { initializeSentry } from './config/sentry';
-import { getLogger } from './config/logger'
+import {getLogger, globalLoggingLevel} from './config/logger'
 
 const isProd = process.env.NODE_ENV === 'production';
 const { redisOptions } = getRedisInfo('probot');
 
 
-const probot = new Probot({
+const probot = createProbot({
   id: Number(process.env.APP_ID),
   secret: process.env.WEBHOOK_SECRET,
   cert: PrivateKey.findPrivateKey(),
   port: Number(process.env.TUNNEL_PORT) || Number(process.env.PORT) || 8080,
   webhookPath: '/github/events',
   webhookProxy: process.env.WEBHOOK_PROXY_URL,
-  redisConfig: redisOptions
+  redisConfig: redisOptions,
 });
+
+probot.logger.level(globalLoggingLevel)
 
 async function createDBTables(logger: bunyan) {
   try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import App from './configure-robot';
 import bunyan from 'bunyan';
 import { exec } from 'child_process';
 import { initializeSentry } from './config/sentry';
-import {getLogger, globalLoggingLevel} from './config/logger'
+import {getLogger, overrideProbotLoggingMethods} from './config/logger'
 
 const isProd = process.env.NODE_ENV === 'production';
 const { redisOptions } = getRedisInfo('probot');
@@ -23,7 +23,7 @@ const probot = createProbot({
   redisConfig: redisOptions,
 });
 
-probot.logger.level(globalLoggingLevel)
+overrideProbotLoggingMethods(probot.logger)
 
 async function createDBTables(logger: bunyan) {
   try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import './config/env'; // Important to be before other dependencies
 import throng from 'throng';
 import getRedisInfo from './config/redis-info';
 import * as PrivateKey from 'probot/lib/private-key';
-import { createProbot } from 'probot';
+import { Probot } from 'probot';
 import App from './configure-robot';
 import bunyan from 'bunyan';
 import { exec } from 'child_process';
@@ -11,14 +11,14 @@ import { initializeSentry } from './config/sentry';
 const isProd = process.env.NODE_ENV === 'production';
 const { redisOptions } = getRedisInfo('probot');
 
-const probot = createProbot({
+const probot = new Probot({
   id: Number(process.env.APP_ID),
   secret: process.env.WEBHOOK_SECRET,
   cert: PrivateKey.findPrivateKey(),
   port: Number(process.env.TUNNEL_PORT) || Number(process.env.PORT) || 8080,
   webhookPath: '/github/events',
   webhookProxy: process.env.WEBHOOK_PROXY_URL,
-  redisConfig: redisOptions,
+  redisConfig: redisOptions
 });
 
 async function createDBTables(logger: bunyan) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,11 @@ import App from './configure-robot';
 import bunyan from 'bunyan';
 import { exec } from 'child_process';
 import { initializeSentry } from './config/sentry';
+import { getLogger } from './config/logger'
 
 const isProd = process.env.NODE_ENV === 'production';
 const { redisOptions } = getRedisInfo('probot');
+
 
 const probot = new Probot({
   id: Number(process.env.APP_ID),
@@ -45,7 +47,7 @@ async function createDBTables(logger: bunyan) {
 async function start() {
   initializeSentry();
 
-  const logger = bunyan.createLogger({ name: 'App start' });
+  const logger = getLogger( 'startup' );
 
   // Create tables for micros environments
   if (isProd) await createDBTables(logger);

--- a/src/middleware/log-middleware.ts
+++ b/src/middleware/log-middleware.ts
@@ -39,6 +39,7 @@ declare global {
   }
 }
 
+export const middlewareLoggerName = 'log-middleware';
 
 export default (req: Request, _: Response, next: NextFunction): void => {
   req.addLogFields = (fields: Record<string, unknown>):void => {
@@ -50,8 +51,12 @@ export default (req: Request, _: Response, next: NextFunction): void => {
   };
 
   // Replaces req.log with default bunyan logger. So we can override Probot logger
-  req.log = getLogger('log-middleware');
-  const reqId = req.header('X-Request-Id') || uuidv4()
+  req.log = getLogger(middlewareLoggerName);
+
+  const reqId = req.headers['x-request-id'] ||
+    req.headers['x-github-delivery'] ||
+    uuidv4();
+
   req.addLogFields({requestId: reqId });
 
   next();

--- a/src/middleware/log-middleware.ts
+++ b/src/middleware/log-middleware.ts
@@ -1,6 +1,7 @@
-import {logger} from 'probot/lib/logger';
+import { getLogger } from '../config/logger';
 import {NextFunction, Request, Response} from 'express';
 import Logger from 'bunyan';
+import { v4 as uuidv4 } from 'uuid';
 
 /*
 
@@ -47,8 +48,9 @@ export default (req: Request, _: Response, next: NextFunction): void => {
     }
   };
 
-  req.log = req.log || logger;
-  req.addLogFields({requestId: req.header('X-Request-Id')});
+  req.log = req.log || getLogger('log-middleware');
+  const reqId = req.header('X-Request-Id') || uuidv4()
+  req.addLogFields({requestId: reqId });
 
   next();
 };

--- a/src/middleware/log-middleware.ts
+++ b/src/middleware/log-middleware.ts
@@ -39,6 +39,7 @@ declare global {
   }
 }
 
+
 export default (req: Request, _: Response, next: NextFunction): void => {
   req.addLogFields = (fields: Record<string, unknown>):void => {
     if (req.log) {
@@ -48,7 +49,8 @@ export default (req: Request, _: Response, next: NextFunction): void => {
     }
   };
 
-  req.log = req.log || getLogger('log-middleware');
+  // Replaces req.log with default bunyan logger. So we can override Probot logger
+  req.log = getLogger('log-middleware');
   const reqId = req.header('X-Request-Id') || uuidv4()
   req.addLogFields({requestId: reqId });
 

--- a/src/models/axios-error-event-decorator.ts
+++ b/src/models/axios-error-event-decorator.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/explicit-module-boundary-types */
 import url from 'url';
-import bunyan from 'bunyan';
 /*
  * Adds request/response metadata to a Sentry event for an Axios error
  * To use, pass AxiosErrorEventDecorator.decorate to scope.addEventProcessor
@@ -68,9 +67,6 @@ export default class AxiosErrorEventDecorator {
   }
 
   generateFingerprint() {
-    const logger = bunyan.createLogger({ name: 'AXIOS ERROR' });
-    logger.info(`AXIOS ERROR:`, this.request.path);
-    logger.info(`AXIOS ERROR:`, typeof this.request.path);
     const { pathname } = url.parse(this.request.path);
 
     return [

--- a/src/models/sequelize.ts
+++ b/src/models/sequelize.ts
@@ -1,5 +1,5 @@
 import Sequelize from 'sequelize';
-import { logger } from 'probot/lib/logger';
+import logger from '../config/logger';
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 // TODO: config misses timezone config to force to UTC, defaults to local timezone of PST
@@ -9,7 +9,7 @@ const config = require('../../db/config.json')[nodeEnv];
 config.benchmark = true;
 config.logging = config.disable_sql_logging
   ? undefined
-  : (query, ms) => logger.debug({ ms }, query);
+  : (query, ms) => logger.debug({ms}, query);
 
 export const sequelize = config.use_env_variable
   ? new Sequelize.Sequelize(process.env[config.use_env_variable], config)

--- a/src/models/subscription.ts
+++ b/src/models/subscription.ts
@@ -2,6 +2,7 @@ import Sequelize from "sequelize";
 import { queues } from "../worker/main";
 import { Job } from "bull";
 import _ from "lodash";
+import logger from '../config/logger';
 
 export enum SyncStatus {
   PENDING = "PENDING",
@@ -145,7 +146,7 @@ export default class Subscription extends Sequelize.Model {
           repos: {}
         }
       });
-      console.log("Starting Jira sync");
+      logger.info("Starting Jira sync");
       return queues.discovery.add({ installationId, jiraHost });
     }
 

--- a/src/send-sync-status-metrics.ts
+++ b/src/send-sync-status-metrics.ts
@@ -1,10 +1,12 @@
 import dotenv from 'dotenv';
+import {queues} from './worker/main';
+import logger from './config/logger';
+
 dotenv.config();
-import { queues } from './worker/main'
 
 queues.metrics.add({})
   .then(() => process.exit(0))
   .catch((error) => {
-    console.log('An error occurred while enqueuing the metrics job:', error)
+    logger.error(error, 'An error occurred while enqueuing the metrics job')
     process.exit(1)
   })

--- a/src/sync/discovery.ts
+++ b/src/sync/discovery.ts
@@ -51,5 +51,6 @@ export const discovery = (app: Application, queues) => async (job) => {
     queues.installation.add({ installationId, jiraHost, startTime }, jobOpts);
   } catch (err) {
     app.log.error(`ERROR: discovery error: ${err}`);
+    app.log.error(`ERROR: discovery error:`, err);
   }
 };

--- a/src/sync/installation.ts
+++ b/src/sync/installation.ts
@@ -13,7 +13,9 @@ import getBranches from './branches';
 import getCommits from './commits';
 import { Application } from 'probot';
 import { metricHttpRequest, metricSyncStatus } from '../config/metric-names';
-import { logger } from 'probot/lib/logger';
+import { getLogger } from '../config/logger';
+
+const logger = getLogger('sync.installation');
 
 const tasks = {
   pull: getPullRequests,

--- a/src/sync/pull-request.ts
+++ b/src/sync/pull-request.ts
@@ -2,7 +2,7 @@ import url from 'url';
 import transformPullRequest from './transforms/pull-request';
 import statsd from '../config/statsd';
 import { GitHubAPI } from 'probot';
-import bunyan from 'bunyan';
+import { getLogger } from '../config/logger';
 import { metricHttpRequest } from '../config/metric-names';
 /**
  * @typedef {object} RepositoryObject
@@ -14,6 +14,8 @@ import { metricHttpRequest } from '../config/metric-names';
  * @property {string} full_name
  */
 
+const logger = getLogger('sync.pull-request');
+
 /**
  * Find the next page number from the response headers.
  */
@@ -23,7 +25,6 @@ export const getNextPage = (headers: Headers = {}): number => {
   if (!nextUrl) {
     return undefined;
   }
-  const logger = bunyan.createLogger({ name: 'pr' });
   logger.info(`pr:`, nextUrl);
   logger.info(`pr:`, typeof nextUrl);
   const parsed = url.parse(nextUrl).query.split('&');

--- a/src/tracking/index.ts
+++ b/src/tracking/index.ts
@@ -1,7 +1,7 @@
 import https from 'https';
 import axios from 'axios';
 import crypto from 'crypto';
-import { logger } from 'probot/lib/logger';
+import logger from '../config/logger';
 import statsd, { asyncDistTimer } from '../config/statsd';
 import { Action } from '../proto/v0/action';
 import { metricHttpRequest } from '../config/metric-names';

--- a/src/util/filteringStream.ts
+++ b/src/util/filteringStream.ts
@@ -1,4 +1,5 @@
-import stream from 'stream';
+import { Writable } from 'stream';
+import {middlewareLoggerName} from "../middleware/log-middleware";
 
 /**
  * Creates a writable stream that prevents HTTP logs from being logged
@@ -12,7 +13,7 @@ import stream from 'stream';
  * @return {WritableStream} that you can pipe bunyan output into
  */
 const filteringStream = (out) => {
-  const writable = new stream.Writable({
+  const writable = new Writable({
     write: function(chunk, encoding, next) {
       if (!shouldBeFiltered(chunk)) {
         out.write(chunk, encoding)
@@ -23,10 +24,12 @@ const filteringStream = (out) => {
   return writable
 }
 
-
+//TODO Remove this code when there will be convenient way to do it in Probot.
+//See https://github.com/probot/probot/issues/1577
 const shouldBeFiltered = (chunk: any) : boolean => {
   return chunk.includes && (chunk.includes("GET /")
-    || chunk.includes("POST /") || chunk.includes("DELETE /"))
+    || chunk.includes("POST /") || chunk.includes("DELETE /")) &&
+    chunk.includes(middlewareLoggerName)
 }
 
 

--- a/src/util/filteringStream.ts
+++ b/src/util/filteringStream.ts
@@ -27,9 +27,9 @@ const filteringStream = (out) => {
 //TODO Remove this code when there will be convenient way to do it in Probot.
 //See https://github.com/probot/probot/issues/1577
 const shouldBeFiltered = (chunk: any) : boolean => {
-  return chunk.includes && (chunk.includes("GET /")
-    || chunk.includes("POST /") || chunk.includes("DELETE /")) &&
-    chunk.includes(middlewareLoggerName)
+  return chunk.includes && chunk.includes(middlewareLoggerName) &&
+    (chunk.includes("GET /") || chunk.includes("POST /") || chunk.includes("DELETE /"))
+
 }
 
 

--- a/src/util/filteringStream.ts
+++ b/src/util/filteringStream.ts
@@ -27,8 +27,7 @@ const filteringStream = (out) => {
 //TODO Remove this code when there will be convenient way to do it in Probot.
 //See https://github.com/probot/probot/issues/1577
 const shouldBeFiltered = (chunk: any) : boolean => {
-  return chunk.includes && chunk.includes(middlewareLoggerName) &&
-    (chunk.includes("GET /") || chunk.includes("POST /") || chunk.includes("DELETE /"))
+  return !!chunk.toString().match(`${middlewareLoggerName}.*(GET|POST|DELETE|PUT|PATCH) /`)
 
 }
 

--- a/src/util/filteringStream.ts
+++ b/src/util/filteringStream.ts
@@ -1,0 +1,33 @@
+import stream from 'stream';
+
+/**
+ * Creates a writable stream that prevents HTTP logs from being logged
+ *
+ * It is done to filter out HTTP logs which are coming from Probot.
+ * Unfortunately there is no other way to disable these logs.
+ *
+ * @name filteringStream
+ * @function
+ * @param out {Stream} original stream
+ * @return {WritableStream} that you can pipe bunyan output into
+ */
+const filteringStream = (out) => {
+  const writable = new stream.Writable({
+    write: function(chunk, encoding, next) {
+      if (!shouldBeFiltered(chunk)) {
+        out.write(chunk, encoding)
+      }
+      next();
+    }
+  });
+  return writable
+}
+
+
+const shouldBeFiltered = (chunk: any) : boolean => {
+  return chunk.includes && (chunk.includes("GET /")
+    || chunk.includes("POST /") || chunk.includes("DELETE /"))
+}
+
+
+export default filteringStream

--- a/src/worker/app.ts
+++ b/src/worker/app.ts
@@ -5,6 +5,7 @@
 import {Application, createProbot} from 'probot';
 import { findPrivateKey } from 'probot/lib/private-key';
 import setupDeepcheck from "../deepcheck";
+import {globalLoggingLevel} from "../config/logger";
 
 export const probot = createProbot({
   id: Number(process.env.APP_ID),
@@ -25,6 +26,8 @@ const App = async (app: Application): Promise<Application> => {
 
 // We are always behind a proxy, but we want the source IP
 probot.server.set('trust proxy', true);
+
+probot.logger.level(globalLoggingLevel)
 
 // Load an empty app so we can get access to probot's auth handling
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/worker/app.ts
+++ b/src/worker/app.ts
@@ -5,7 +5,7 @@
 import {Application, createProbot} from 'probot';
 import { findPrivateKey } from 'probot/lib/private-key';
 import setupDeepcheck from "../deepcheck";
-import {globalLoggingLevel} from "../config/logger";
+import {overrideProbotLoggingMethods} from "../config/logger";
 
 export const probot = createProbot({
   id: Number(process.env.APP_ID),
@@ -27,7 +27,7 @@ const App = async (app: Application): Promise<Application> => {
 // We are always behind a proxy, but we want the source IP
 probot.server.set('trust proxy', true);
 
-probot.logger.level(globalLoggingLevel)
+overrideProbotLoggingMethods(probot.logger)
 
 // Load an empty app so we can get access to probot's auth handling
 // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
In this pull request I did the following:

1. Created a logger.ts file with shared logger for the application (Same changes as @rachellerathbone  made before)
2. Used this logger everywhere where we could. (Some Probot logs are still use its custom logger, hence we can't override it)
3. Added a filtering stream to the logger, to remove HTTP access logs which hardcoded in Probot
4. Added overrides for console.log (and its other logging functions) to use our common logging and ES Lint rule to prohibit console.log usage

I am currently testing this in ddev. In the next PR I'll get through all our logs and make sure that they comply our logging standard.