### PR TITLE
HOTFIX-ARC-8: Send right object to reduceProjectKeys function.

### DIFF
--- a/lib/github/deployment.js
+++ b/lib/github/deployment.js
@@ -12,7 +12,8 @@ module.exports = async (context, jiraClient) => {
 
   await jiraClient.deployment.submit(jiraPayload);
 
-  const projects = reduceProjectKeys(jiraPayload);
+  const projects = [];
+  jiraPayload.deployments.map(deployment => reduceProjectKeys(deployment, projects));
 
   for (const projectKey of projects) {
     await Project.upsert(projectKey, jiraClient.baseURL);

--- a/lib/github/workflow.js
+++ b/lib/github/workflow.js
@@ -12,7 +12,8 @@ module.exports = async (context, jiraClient) => {
 
   await jiraClient.workflow.submit(jiraPayload);
 
-  const projects = reduceProjectKeys(jiraPayload);
+  const projects = [];
+  jiraPayload.builds.map(build => reduceProjectKeys(build, projects));
 
   for (const projectKey of projects) {
     await Project.upsert(projectKey, jiraClient.baseURL);


### PR DESCRIPTION
We need to send only `builds` or `deployments` because they contain `issueKeys` and not the whole `jiraPayload`. Same as it's done for [branch](https://github.com/integrations/jira/blob/master/lib/github/branch.js#L17), for example.