### PR TITLE
ARC-387 redirect to github/configuration

### DIFF
--- a/src/frontend/get-github-configuration.ts
+++ b/src/frontend/get-github-configuration.ts
@@ -1,6 +1,7 @@
 import JWT from 'atlassian-jwt';
 import {Installation} from '../models';
 import {NextFunction, Request, Response} from 'express';
+import { getJiraMarketplaceUrl } from '../util/getUrl';
 
 export default async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   if (!req.session.githubToken) {
@@ -56,6 +57,5 @@ export default async (req: Request, res: Response, next: NextFunction): Promise<
     }
   }
 
-  // TODO: Triplicate code.  Need to centralize.
-  res.redirect(`${req.session.jiraHost}/plugins/servlet/upm/marketplace/plugins/com.github.integration.production`);
+  res.redirect(getJiraMarketplaceUrl(req.session.jiraHost));
 };

--- a/src/frontend/get-github-setup.ts
+++ b/src/frontend/get-github-setup.ts
@@ -1,10 +1,22 @@
-import {jiraDomainOptions} from './validations';
-import {NextFunction, Request, Response} from 'express';
+import { jiraDomainOptions } from './validations';
+import { NextFunction, Request, Response } from 'express';
+import { getGitHubConfigurationUrl } from '../util/getUrl';
 
-export default (req: Request, res: Response, next: NextFunction):void => {
+/*
+When this request is made: Installing from Jira Marketplace - GitHub org does not have Jira installed.
+Redirects users back to github/configuration to install their Jira instance in GitHub org/s.
+If the installation was done from Jira Marketplace, the app is already installed.
+*/
+export default (req: Request, res: Response, next: NextFunction): void => {
   if (req.session.jiraHost) {
-    // TODO: Make URL an environment variable?  Change it to point it to plugin directly instead of search
-    return res.redirect(`${req.session.jiraHost}/plugins/servlet/upm/marketplace/plugins/com.github.integration.production`);
+    const { host: githubHost, session } = req;
+    const { jwt, jiraHost } = session;
+
+    const urlParams = { githubHost, jwt, jiraHost };
+
+    /* We don't need to redirect to the marketplace here. If a user has installed from Jira, the
+    GitHub app is already installed. */
+    return res.redirect(getGitHubConfigurationUrl(urlParams));
   }
 
   res.render('github-setup.hbs', {

--- a/src/frontend/post-github-setup.ts
+++ b/src/frontend/post-github-setup.ts
@@ -1,8 +1,14 @@
-import {jiraDomainOptions, validJiraDomains} from './validations';
-import {Request, Response} from 'express';
+import { jiraDomainOptions, validJiraDomains } from './validations';
+import { Request, Response } from 'express';
+import { getJiraMarketplaceUrl } from '../util/getUrl';
 
+/*
+When this request is made: Installing from GitHub marketplace.
+Renders https://jira.github.com/github/setup and prompts user to enter a Jira site.
+User is either prompted to login into GitHub, or if already logged in, is redirected to Jira Marketplace.
+*/
 export default (req: Request, res: Response): void => {
-  const {jiraSubdomain, jiraDomain} = req.body;
+  const { jiraSubdomain, jiraDomain } = req.body;
   if (!validJiraDomains(jiraSubdomain, jiraDomain)) {
     res.status(400);
     return res.render('github-setup.hbs', {
@@ -17,9 +23,8 @@ export default (req: Request, res: Response): void => {
   req.session.jiraHost = `https://${jiraSubdomain}.${jiraDomain}`;
 
   res.redirect(
-    req.session.githubToken ?
-      // TODO: duplicate code. Need to centralize this.
-      `${req.session.jiraHost}/plugins/servlet/upm/marketplace/plugins/com.github.integration.production` :
-      '/github/login'
+    req.session.githubToken
+      ? getJiraMarketplaceUrl(req.session.jiraHost)
+      : '/github/login',
   );
 };

--- a/src/util/getUrl.ts
+++ b/src/util/getUrl.ts
@@ -1,0 +1,14 @@
+interface IUrlParams {
+  githubHost: string;
+  jwt: string;
+  jiraHost: string;
+}
+
+export const getGitHubConfigurationUrl = (urlParams: IUrlParams): string => {
+  const { githubHost, jwt, jiraHost } = urlParams;
+
+  return `https://${githubHost}/github/configuration?jwt=${jwt}&xdm_e=${jiraHost}`;
+};
+
+export const getJiraMarketplaceUrl = (jiraHost: string): string =>
+  `https://${jiraHost}/plugins/servlet/upm/marketplace/plugins/com.github.integration.production`;


### PR DESCRIPTION
This is first of many steps to improve the painful installation flow we have in place. These changes focus on improving the experience for users who are installing the GitHub for Jira app from the Jira marketplace and do not have their Jira instance installed in their GitHub org. As seen in the screenshot below, after a user clicks the green install button from the 'Install Jira' page, they are then redirected to the Jira marketplace. As the app would've already been installed, the steps in the purple box are redundant (another redundant path is to go marketplace > apps in navbar > manage apps > get started).

<img width="1663" alt="Screen Shot 2021-07-20 at 9 54 24 am" src="https://user-images.githubusercontent.com/37155488/126254191-2e7d3a18-e6af-46d1-9832-d48f60274c6c.png">

With the updated url redirect, users will skip these steps and land back on the github/configuration page with their org now displayed in the list with the option to 'Install' (see last screen to the right in above screenshot). The install flow is still far too long 🥴 but it's a start.

**Additional changes on this PR:** I cleaned up the marketplace urls and moved both the marketplace and github/configuration url out into a central location so we could remove some of our cleanup comments.

**What's not included in this PR**: updating the redirect url when a user installs the app from GitHub. Ideally, if a user installs from GitHub:
- if they don't have the GitHub installed in Jira, they get directed from github/setup to the jira marketplace
- if they do have it installed (maybe they installed it but never completed the setup or the Jira side) instead of being directed to the marketplace, they get redirected to github/configuration.
The current stream of work focuses on improving the installation flow from Jira. Improving the flow from GitHub is a separate stream we will work on later.