### PR TITLE
ARC-407: Fix workflow mapping before sending it to Jira.

### DIFF
--- a/lib/transforms/workflow.js
+++ b/lib/transforms/workflow.js
@@ -45,7 +45,7 @@ function mapPullRequests(pull_requests) {
   ));
 }
 module.exports = async (payload) => {
-  const { workflow_run } = payload;
+  const { workflow_run, workflow } = payload;
   const { issueKeys } = parseSmartCommit(`${workflow_run.head_branch}\n${workflow_run.head_commit.message}`);
 
   if (!issueKeys) {
@@ -57,7 +57,7 @@ module.exports = async (payload) => {
       product: 'GitHub Actions',
       builds: [{
         schemaVersion: '1.0',
-        pipelineId: workflow_run.id,
+        pipelineId: workflow.id,
         buildNumber: workflow_run.run_number,
         updateSequenceNumber: Date.now(),
         displayName: workflow_run.name,


### PR DESCRIPTION
Send `workflow.id` instead of `workflow_run.id` as the pipeline id to Jira.

Solves:
https://customerfeedback.atlassian.net/browse/JSF-2097
https://customerfeedback.atlassian.net/browse/JSF-2094
and https://github.com/integrations/jira/issues/545